### PR TITLE
Update add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,4 +1,5 @@
 glthubs.com
+tabitha-cambodia.org
 ukreturnclaim.com
 copyirghtagencymediacenter.ml
 spiffcoin.net


### PR DESCRIPTION
Site has been the host of two malware subdomains.

```https://tabitha-cambodia.org//app/Model/CpgredesPerts/cgi_b!n/cg%c4%af_bin/ijj%c5%939p0ol932/871%c3%actip9oling/P%c4%abBalyc0%c5%93uk/80%c3%bce2101b%c4%8d/Bbbw%c4%99biay/lopsdjjjh%c3%aab%c3%b8jhxhas%c5%93jhghbvssiu8e90j/P%c3%bfBay/?fbclid=IwAR1F2ugJu5vjikpoyymFv4UfN0tX-mziKJGg2Mo-Up_2Q-dmGcVSJM6X0Kg```

and

```https://tabitha-cambodia.org//app/Model/CpgredesPerts/cgi_b!n/cg%c4%af_bin/ijj%c5%939p0ol932/871%c3%actip9oling/P%c4%abBalyc0%c5%93uk/80%c3%bce2101b%c4%8d/Bbbw%c4%99biay/lopsdjjjh%c3%aab%c3%b8jhxhas%c5%93jhghbvssiu8e90j/P%c3%bfBay/```

so maybe best to blacklist entire domain.