### PR TITLE
Removal: tabitha-cambodia.org

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,5 +1,4 @@
 glthubs.com
-tabitha-cambodia.org
 ukreturnclaim.com
 copyirghtagencymediacenter.ml
 spiffcoin.net

--- a/add-domain
+++ b/add-domain
@@ -468,7 +468,6 @@ survivecovid19.ga
 survivecovid19.ml
 survivecovid19.tk
 survivvruscorona.us
-tabitha-cambodia.org//app/Model/CpgredesPerts/cgi_b!n/cg%c4%af_bin/ijj%c5%939p0ol932/871%c3%actip9oling/P%c4%abBalyc0%c5%93uk/80%c3%bce2101b%c4%8d/Bbbw%c4%99biay/lopsdjjjh%c3%aab%c3%b8jhxhas%c5%93jhghbvssiu8e90j/P%c3%bfBay/?fbclid=IwAR1F2ugJu5vjikpoyymFv4UfN0tX-mziKJGg2Mo-Up_2Q-dmGcVSJM6X0Kg
 testcorona.se
 theanticorona.com
 thecoronahomeexpert.com

--- a/add-link
+++ b/add-link
@@ -1,5 +1,4 @@
 https://serverdomainsetting.weebly.com/
-tabitha-cambodia.org//app/Model/CpgredesPerts/cgi_b!n/cg%c4%af_bin/ijj%c5%939p0ol932/871%c3%actip9oling/P%c4%abBalyc0%c5%93uk/80%c3%bce2101b%c4%8d/Bbbw%c4%99biay/lopsdjjjh%c3%aab%c3%b8jhxhas%c5%93jhghbvssiu8e90j/P%c3%bfBay/?fbclid=IwAR1F2ugJu5vjikpoyymFv4UfN0tX-mziKJGg2Mo-Up_2Q-dmGcVSJM6X0Kg
 https://61f0r.r.ah.d.sendibm4.com/mk/cl/f/P4c6noeIW31hDASG9uhJPK1qjzYrNXTcbnOstxUYKsIbiLznkLiPZBx9NrkbmmHSlK-yL25tLbHqPxu5gjciHqr10x8IJ_ciLkEO2CEwa_p4haEWnnFmQvzDDFqtk-EL-Qlb49d7koD9-1yLWv9WAx-DbdT6T4t7f0Az8SuK4nkJd-MdRg
 https://lcmission.com.ru/online.standardbank.co.za
 https://worldcup2018goals.com/online.standardbank.co.za


### PR DESCRIPTION
Domain is inactive.

Follow https://github.com/mitchellkrogza/phishing/pull/11/ or https://mypdns.org/my-privacy-dns/matrix/-/issues/1841 for upcoming details/changes