### PR TITLE
add www-rsblox.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -515,3 +515,4 @@ restore637908-coinbase-us.web.app
 jobsamericanairline.com
 systemww.trackinglink.top
 stearncomminuty.ru
+www-rsblox.com


### PR DESCRIPTION
`www-rsblox.com`
Full URL: hxxp://www-rsblox.com/users/291728/profile
Roblox phish complete with fake 2FA page once you've entered your login details
From https://scammer.info/t/you-have-been-selected-as-the-winner-of-the-june-verify-event-discord-scam/76227
Also: https://www.virustotal.com/gui/url/34bf7dbe6527336524e32168e606147f64d8bcc3120101b53cbb4829b3fe6a6f/detection