### PR TITLE
adds discord-nitro.ru.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -529,3 +529,4 @@ wy.adyboh.com
 xml.lgin.msa.trafficmanager.net
 zc11m.csb.app
 ziaco-corona.work
+discord-nitro.ru.com


### PR DESCRIPTION
full url: hxxp://discord-nitro.ru.com/nitro
from: https://scammer.info/t/get-discord-nitro-for-free-from-steam-store-scam/79992