### PR TITLE
Added the diff lists with a first comment inside

### DIFF
--- a/IP-addr.cidr.in-addr.arpa
+++ b/IP-addr.cidr.in-addr.arpa
@@ -1,0 +1,2 @@
+# example address
+# 24.1.2.0.192 # rfc:5737

--- a/IP-addr.cidr.list
+++ b/IP-addr.cidr.list
@@ -1,0 +1,2 @@
+# example address
+# 192.0.2.1/24 # rfc:5737

--- a/IP-addr.in-addr.arpa
+++ b/IP-addr.in-addr.arpa
@@ -1,0 +1,2 @@
+# example address
+# 1.2.0.192 # rfc:5737

--- a/IP-addr.list
+++ b/IP-addr.list
@@ -1,0 +1,2 @@
+# example address
+# 192.0.2.1 # rfc:5737

--- a/add-domain
+++ b/add-domain
@@ -5,7 +5,7 @@ supportscontact.com
 bluebadge-verifcation.com
 2019coronavirusinfo.com
 2020logs.duckdns.org
-Cdcgov.org
+cdcgov.org
 abncoronaveiligomgeving.live
 ac19.ir
 actionagainstcovid19.com

--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -1,0 +1,1 @@
+firebaseio.com # NOTE: This is not necessarily an actual domain to become blocked on a wildcard level, its just a random pick from the add-domain list


### PR DESCRIPTION
There is a few thing I would like to suggest for the https://github.com/mitchellkrogza/Phishing as there is several use cases which isn't covered.

# Intro
Currently all phishing IP addresses is directed to https://mypdns.org/my-privacy-dns/matrix/-/blob/master/source/phishing/rpz-ip which is fine by me, it help maintain my lists :smirk: and if it should be, we can easily integrate your URL lists to that repository, however that is not what this MR (PR) is about, it is about how to make it capable of supporting a broader variety of third party sources in a optimal an minimal way.

## Part 1
In the first part of this MR we will cover the committing of IP-addresses for phishing, whereas the following suggested list will be:

### IP-addr.cidr.list
Forwarded ip with CIDR notation

### IP-addr.list
Forwarded ip with-_OUT_ CIDR notation

### IP-addr.cidr.in-addr.arpa
Reversed ip with CIDR notation (ip 1.2.3.4 should be listed as cidr.4.3.2.1)

### IP-addr.in-addr.arpa
Reversed ip with-_OUT_ CIDR notation (ip 1.2.3.4 should be listed as 4.3.2.1)

Users can (shall) then only add information's to the `IP-addr.cidr.list` the other 3 lists can stay locked and be generate through code. We now covers all use cases and any decoding should not be needed for any third party (Based on the concept behind my own lists layout).

## Part 2

In the seconds part of the MR, we add the `add-wildcard-domain` is as the name suggests a lists to be used to domain for where there are no hope (or risk for blocking any legit usage)

## Epilogue
For any modification, pushed, editing etc please do use https://mypdns.org/spirillen/phishing/-/tree/feature-iplists to avoid a complete merge hell