### PR TITLE
New issue templ. for FP's

### DIFF
--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -26,27 +26,32 @@ body:
         
         Please warn with "NSFW" where applicable.
       placeholder: |
-        `example.com`
-        `https://example.org/phishing`
-        `192.0.2.0/24`
+        example.com
+        https://example.org/phishing
+        192.0.2.0/24
       render: css
     validations:
       required: true
 
-  - type: dropdown
+  - type: checkboxes
     id: source
     attributes:
       label: More Information
       description: |
         How did you discover your IP-address or domain was listed in the Phishing or Phishing.Database?
-      multiple: true
       options:
-        - mitchellkrogza Phishing
-        - mitchellkrogza Phishing.Database
-        - Website was hacked
-        - Listed as Phishing on Phishtank or OpenPhish
-        - Listed on VirusTotal
-        - Other (Please note where in 'Related external source' below)
+        - label: mitchellkrogza Phishing
+          required: false
+        - label: mitchellkrogza Phishing.Database
+          required: false
+        - label: Website was hacked
+          required: false
+        - label: Listed as Phishing on Phishtank or OpenPhish
+          required: false
+        - label: Listed on VirusTotal
+          required: false
+        - label: Other (Please tell us where in *Related external source* below)
+          required: false
 
   - type: textarea
     id: source_external
@@ -57,7 +62,7 @@ body:
 
         One link per line.
       placeholder: |
-        `https://example.org`
+        https://example.org
       render:
         - markdown
     validations:
@@ -71,10 +76,7 @@ body:
         If you feel a screenshot can say more than 1000 hard drives, do
         please feel free to add it here :smiley:
 
-        **TIP** Place your mouse on the line just above the `</details>`
-        and paste your screenshot and make sure that there is at least one
-        line spacing before and after the image code line. The tip will add"
-        one line after the paste :wink:
+        **INFO** There need to be at least one blank line separating before and after the image line
 
         Copy paste these lines to the text area below
 

--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -15,14 +15,14 @@ body:
         
         The second step is to rest assured one of our maintainers will address your issue as soon as possible.
 
-        Please make sure you have provided as much information details as possible to help speed up the process.
+        Please make sure you have provided as much information and details as possible to help speed up the process.
 
   - type: textarea
     id: record
     attributes:
       label: Domain/URL/IP(s) you believe NOT to be Phishing
       description: |
-        Please list any domains and links listed here which you believe are a false positive.
+        Please give us a list of FQDN (domains) or complete links (URL's) that you believe are a false positive.
         
         Please warn with "NSFW" where applicable.
       placeholder: |
@@ -78,7 +78,7 @@ body:
 
         **INFO** There need to be at least one blank line separating before and after the image line
 
-        Copy paste these lines to the text area below
+        Copy and paste the lines to the text area below.
 
         ```
         <details><summary>Click to expand</summary>

--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -104,7 +104,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Users who understand github and creating Pull Requests can assist us with faster removals by sending a PR on the `whitelist.me` file at
-        https://github.com/mitchellkrogza/Phishing.Database/blob/master/whitelist.me/whitelist.me
+        Users who understand github and creating Pull Requests can assist us with faster removals by sending a PR on the `falsepositive.list` file at
+        https://github.com/mitchellkrogza/phishing/blob/main/falsepositive.list
 
         Please include the same above information to help speed up the whitelisting process.

--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -1,0 +1,110 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
+name: False Positive Report
+description: File a Phishing report
+labels: ["False Positive"]
+assignees:
+  - mitchellkrogza
+  - funilrys
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We understand being listed on a Phishing Database like this can be frustrating and embarrassing for many web site owners.
+
+        The first step is to remain calm.
+        
+        The second step is to rest assured one of our maintainers will address your issue as soon as possible.
+
+        Please make sure you have provided as much information details as possible to help speed up the process.
+
+  - type: textarea
+    id: record
+    attributes:
+      label: Domain/URL/IP(s) you believes NOT to be Phishing
+      description: |
+        Please list any domains and links listed here which you believe are a false positive.
+        
+        Please warn with "NSFW" where applicable.
+      placeholder: |
+        `example.com`
+        `https://example.org/phishing`
+        `192.0.2.0/24`
+      render: css
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: More Information
+      description: |
+        How did you discover your IP-address or domain was listed in the Phishing or Phishing.Database?
+      multiple: true
+      options:
+        - mitchellkrogza Phishing
+        - mitchellkrogza Phishing.Database
+        - Website was hacked
+        - Listed as Phishing on Phishtank or OpenPhish
+        - Listed on VirusTotal
+        - Other (Please note where in 'Related external source' below)
+
+  - type: textarea
+    id: source_external
+    attributes:
+      label: Related external source
+      description: |
+        Please let us know where you found this if not listed above
+
+        One link per line.
+      placeholder: |
+        `https://example.org`
+      render:
+        - markdown
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Screenshot
+      id: Screenshot
+      description: |
+        If you feel a screenshot can say more than 1000 hard drives, do
+        please feel free to add it here :smiley:
+
+        **TIP** Place your mouse on the line just above the `</details>`
+        and paste your screenshot and make sure that there is at least one
+        line spacing before and after the image code line. The tip will add"
+        one line after the paste :wink:
+
+        Copy paste these lines to the text area below
+
+        ```
+        <details><summary>Click to expand</summary>
+        
+        
+        </details>
+        ```
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: |
+        Be as clear as possible: nobody can read your mind, and nobody
+        is looking at your issue over your shoulder.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "## Send a Pull Request for faster removal"
+  - type: markdown
+    attributes:
+      value: |
+        Users who understand github and creating Pull Requests can assist us with faster removals by sending a PR on the `whitelist.me` file at
+        https://github.com/mitchellkrogza/Phishing.Database/blob/master/whitelist.me/whitelist.me
+        
+        Please include the same above information to help speed up the whitelisting process.

--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -20,7 +20,7 @@ body:
   - type: textarea
     id: record
     attributes:
-      label: Domain/URL/IP(s) you believes NOT to be Phishing
+      label: Domain/URL/IP(s) you believe NOT to be Phishing
       description: |
         Please list any domains and links listed here which you believe are a false positive.
         

--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -9,20 +9,24 @@ body:
   - type: markdown
     attributes:
       value: |
-        We understand being listed on a Phishing Database like this can be frustrating and embarrassing for many web site owners.
+        We understand being listed on a Phishing Database like this can be
+        frustrating and embarrassing for many web site owners.
 
         The first step is to remain calm.
         
-        The second step is to rest assured one of our maintainers will address your issue as soon as possible.
+        The second step is to rest assured one of our maintainers will address
+        your issue as soon as possible.
 
-        Please make sure you have provided as much information and details as possible to help speed up the process.
+        Please make sure you have provided as much information and details as
+        possible to help speed up the processing of your whitelisting application.
 
   - type: textarea
     id: record
     attributes:
       label: Domain/URL/IP(s) you believe NOT to be Phishing
       description: |
-        Please give us a list of FQDN (domains) or complete links (URL's) that you believe are a false positive.
+        Please give us a list of FQDN (domains) or complete links (URL's) that
+        you believe are a false positive.
         
         Please warn with "NSFW" where applicable.
       placeholder: |
@@ -38,7 +42,8 @@ body:
     attributes:
       label: More Information
       description: |
-        How did you discover your IP-address or domain was listed in the Phishing or Phishing.Database?
+        How did you discover your IP-address or domain was listed in the
+        Phishing or Phishing.Database?
       options:
         - label: mitchellkrogza Phishing
           required: false
@@ -58,9 +63,7 @@ body:
     attributes:
       label: Related external source
       description: |
-        Please let us know where you found this if not listed above
-
-        One link per line.
+        Please let us know where you found this if not listed above. (One link per line.)
       placeholder: |
         https://example.org
       render:
@@ -76,7 +79,8 @@ body:
         If you feel a screenshot can say more than 1000 hard drives, do
         please feel free to add it here :smiley:
 
-        **INFO** There need to be at least one blank line separating before and after the image line
+        **INFO** There need to be at least one blank line separating before
+        and after the image line
 
         Copy and paste the lines to the text area below.
 
@@ -96,7 +100,7 @@ body:
       label: Describe the issue
       description: |
         Be as clear as possible: nobody can read your mind, and nobody
-        is looking at your issue over your shoulder.
+        is looking over your shoulder.
     validations:
       required: true
 
@@ -106,7 +110,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Users who understand github and creating Pull Requests can assist us with faster removals by sending a PR on the `falsepositive.list` file at
+        Users who understand github and creating Pull Requests can assist us
+        with faster removals by sending a PR on the `falsepositive.list` file at
         https://github.com/mitchellkrogza/phishing/blob/main/falsepositive.list
 
         Please include the same above information to help speed up the whitelisting process.

--- a/.github/ISSUE_TEMPLATE/falsepositive.yml
+++ b/.github/ISSUE_TEMPLATE/falsepositive.yml
@@ -84,7 +84,7 @@ body:
         
         </details>
         ```
-      render: markdown
+      render: false
     validations:
       required: false
 
@@ -106,5 +106,5 @@ body:
       value: |
         Users who understand github and creating Pull Requests can assist us with faster removals by sending a PR on the `whitelist.me` file at
         https://github.com/mitchellkrogza/Phishing.Database/blob/master/whitelist.me/whitelist.me
-        
+
         Please include the same above information to help speed up the whitelisting process.

--- a/.github/ISSUE_TEMPLATE/phishing.yml
+++ b/.github/ISSUE_TEMPLATE/phishing.yml
@@ -69,5 +69,6 @@ body:
       
       </details>
       ```
+    render: false
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/phishing.yml
+++ b/.github/ISSUE_TEMPLATE/phishing.yml
@@ -19,9 +19,9 @@ body:
       notation is, the right value is most likely `/32`, which in short
       means exactly this IP address.
     placeholder: |
-      `example.com`
-      `https://example.org/phishing`
-      `192.0.2.0/24`
+      example.com
+      https://example.org/phishing
+      192.0.2.0/24
     render: true
   validations:
     required: true
@@ -61,6 +61,8 @@ body:
       line spacing before and after the image code line. The tip will add"
       one line after the paste.
       
+      **INFO** There need to be at least one blank line separating before and after the image line
+
       Copy paste these lines to the text area below
 
       ```

--- a/.github/ISSUE_TEMPLATE/phishing.yml
+++ b/.github/ISSUE_TEMPLATE/phishing.yml
@@ -19,7 +19,7 @@ body:
       notation is, the right value is most likely `/32`, which in short
       means exactly this IP address.
     placeholder: |
-      `https://example.com`
+      `example.com`
       `https://example.org/phishing`
       `192.0.2.0/24`
     render: true
@@ -35,7 +35,7 @@ body:
 
       One link per line.
     placeholder: |
-      https://mypdns.org
+      https://example.org
   validations:
     required: false
 
@@ -54,14 +54,16 @@ body:
     id: Screenshot
     description: |
       If you feel a screenshot can say more than 1000 hard drives, do
-      please feel free to add it here :smiley:
+      please feel free to add it here.
 
       **TIP** Place your mouse on the line just above the `</details>`
       and paste your screenshot and make sure that there is at least one
       line spacing before and after the image code line. The tip will add"
-      one line after the paste :wink:
+      one line after the paste.
       
-      ```html
+      Copy paste these lines to the text area below
+
+      ```
       <details><summary>Click to expand</summary>
       
       


### PR DESCRIPTION
With this commit we should now have a template to be used
for reporting False Positives to the phishing database.

I have used the old template as guideline for building this template

There is a live fully testable version available at https://github.com/spirillen/templatetest/issues/new?assignees=mitchellkrogza%2Cfunilrys&labels=False+Positive&template=falsepositive.yml until this PR is merged