### PR TITLE
adds steam phishing scams

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -260,6 +260,7 @@ dating4free.us
 dating4sex.us
 destekol-sessizkalma.net
 dicsordgifts.xyz
+dicsordgive.ru
 directmessageviolation.com
 disccrd.gifts
 discord-nitro.ru.com

--- a/add-domain
+++ b/add-domain
@@ -793,6 +793,7 @@ sohbetlerimiz-sicak.ml
 sondakka.cf
 spiffcoin.net
 steamcomnnulty.com
+steemcoommuntys.com
 stearncomminuty.ru
 stoic-elion.34-125-197-109.plesk.page
 stopcorona.xyz


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
Full URLS: hxxps://steemcoommuntys[.]com/tradeoffer/new/?partner=800990511
hxxps://dicsordgive[.]ru/nitro

## Related external source
https://scammer.info/t/report-a-steam-phishing-site/86785

## Describe the issue
Steam account phishing, very broken and unofficial domain name.
