### PR TITLE
add steelseriesgifts.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -797,6 +797,7 @@ spiffcoin.net
 steamcomnnulty.com
 steemcoommuntys.com
 stearncomminuty.ru
+steelseriesgifts.com
 stoic-elion.34-125-197-109.plesk.page
 stopcorona.xyz
 stopcoronavirus.us.org


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
hxxp://steelseriesgifts[.]com/billing/promotions/vy98rpaEJZnhh5x37agpmC0x

## Related external source
https://scammer.info/t/yo-i-got-some-nitro-left-over-here-scam/87735
https://www.virustotal.com/gui/url/83563cab9082de0426229d5a184e4169305a85039af51b4ef31646d38e93e7f4?nocache=1
## Describe the issue
Discord QR code phishing scam

### Screenshot
![slika](https://user-images.githubusercontent.com/69423184/149400901-f083e340-e086-4c5a-a6f3-d30f67ec11b5.png)
