### PR TITLE
Remove zenodo.org (false positive)

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -1,3 +1,4 @@
 xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.test
 nvidia.com
 voicemod.net
+zenodo.org


### PR DESCRIPTION
Zenodo is a site run by CERN that hosts scientific data

## Domain/URL/IP(s) where you have found the Phishing:


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
In my opinion, zenodo.org is a clear false positive.
Zenodo is a site run by CERN that hosts scientific data

