### PR TITLE
Discord 3 Months free

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1024,3 +1024,4 @@ youareanidiot.cc
 youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 disdorsnltro.com
+djscord-alrdrops.com


### PR DESCRIPTION
djscord-alrdrops.com/

The domain is giving away 3 months of free nitro discord as if they had a partnership with Steam. Then stealing their accounts sharing this link to get more victims.


<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/38168227/149755864-2966038b-8fd2-42e3-b18f-e005c8272cdd.png)

![image](https://user-images.githubusercontent.com/38168227/149755717-a48a4c00-8cc9-4cb0-af88-cb87c7d1a645.png)

</details>
