### PR TITLE
Steam scam

### DIFF
--- a/add-link
+++ b/add-link
@@ -87,4 +87,4 @@ https://websecurityapps-p6wk5.ondigitalocean.app/
 https://iborserv.d9k6hzj6qez2z.amplifyapp.com/
 https://websecurityapps-8kafv.ondigitalocean.app/
 https://iborserv.d9k6hzj6qez2z.amplifyapp.com/
-
+https://steamcommunites.com/tradeoffer=new/partner=1231795725&token=0DaSKkar


### PR DESCRIPTION
Account scam using Trades

```
https://steamcommunites.com/tradeoffer=new/partner=1231795725&token=0DaSKkar
https://steamcommunites.com/
```

This domain/url is impersonating an official version of the Steam trading system. And stealing accounts/items after login to finalize the exchange between victim and scammer

### Screenshot

<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/38168227/149928371-b9dcba42-ca2a-413f-9435-79f7aa5cbdf0.png)

</details>
