### PR TITLE
Update 2  phishing domains

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1026,3 +1026,5 @@ youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 disdorsnltro.com
 djscord-alrdrops.com
+socialearn.co
+soclaiemx.xyz


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:

**The main website appears as `socialearn.co`, they usually point other domains with `XYZ` extensions to this domain.**
```
socialearn.co
soclaiemx.xyz
```

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
A gang that usually communicates through apps like telegram, whatsapp, with the promise that they will get a certain amount of rewards if they sign up. Users' personal information is stolen after signing up

### Screenshot

<details><summary>Click to expand</summary>

![Screenshot](https://user-images.githubusercontent.com/97984982/150006693-2384fe5b-93c5-4f66-bc5e-9a077c4b50ce.png)

**They often distribute malicious links via telegram**
![Screenshot from 2022-01-18 22-39-54](https://user-images.githubusercontent.com/97984982/150006933-c130eb44-d6e2-43fb-856b-612f1045320d.png)


> The English translation of the attacker's message in the image is as follows

Hello, I joined a network called Soclaievn and earned $25.00! You get paid for testing new free apps and posting them on social media. Sign up with my link for an instant $25 signup bonus


</details>
