### PR TITLE
add possible linkedin phishing site

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -698,7 +698,6 @@ l9e5372b.justinstalledpanel.com
 la95a1ab.justinstalledpanel.com
 lgin.msa.trafficmanager.net
 licencefeedback.com
-linkedinin.com
 liveasistance-support.ml
 livecopyrght-service.com
 livecopyright-services.ml
@@ -1017,7 +1016,6 @@ www.web-lgviolationformcenter.com
 www.xserhats.ml
 www.youthful-engelbart.34-125-197-109.plesk.page
 wwwgosuslugj.ru
-www6.linkedinin.com
 wy.adyboh.com
 xenodochial-liskov.34-125-197-109.plesk.page
 xml.lgin.msa.trafficmanager.net

--- a/add-domain
+++ b/add-domain
@@ -698,6 +698,7 @@ l9e5372b.justinstalledpanel.com
 la95a1ab.justinstalledpanel.com
 lgin.msa.trafficmanager.net
 licencefeedback.com
+linkedinin.com
 liveasistance-support.ml
 livecopyrght-service.com
 livecopyright-services.ml
@@ -1016,6 +1017,7 @@ www.web-lgviolationformcenter.com
 www.xserhats.ml
 www.youthful-engelbart.34-125-197-109.plesk.page
 wwwgosuslugj.ru
+www6.linkedinin.com
 wy.adyboh.com
 xenodochial-liskov.34-125-197-109.plesk.page
 xml.lgin.msa.trafficmanager.net

--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -1,2 +1,3 @@
 firebaseio.com # NOTE: This is not necessarily an actual domain to become blocked on a wildcard level, its just a random pick from the add-domain list
 robyoc.online
+linkedinin.com


### PR DESCRIPTION
Stumbled upon this by accident. Redirects to an unknown, possibly malicious site (http://www6.linkedinin.com).

## Domain/URL/IP(s) where you have found the Phishing:
linkedinin.com
www6.linkedinin.com

## Related external source
n/a, discovered myself by accident...

## Describe the issue
This typo is a valid domain that redirects to a blank website that does not appear to be affiliated w/linkedin. 

### Screenshot
<--! If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here :smiley:

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
