### PR TITLE
Added Bitcoin Doubling Scam

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1040,3 +1040,4 @@ zttmct-tlemp.web.app
 disocrds.gift
 steamcommunitvs.com
 disceord.gift
+teslax10.me


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
Found though a discord DM

## Describe the issue
A bitcoin doubling scam. It is seems to just be sent through discord


### Screenshot
![0610f56e-0c54-4072-b4de-8e6fdf55bbd8](https://user-images.githubusercontent.com/13440415/155398219-08864f60-1829-4273-beb8-befb5dd74735.png)

<details><summary>Click to expand</summary>

![0610f56e-0c54-4072-b4de-8e6fdf55bbd8](https://user-images.githubusercontent.com/13440415/155398181-65b74d22-90da-4321-a4db-ed8d97e2142b.png)


</details>
