### PR TITLE
Add Domain: jointhehypesquad-eventsteam.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,5 +1,3 @@
-wsetransport.com
-me2.do
 109.197.125.34.bc.googleusercontent.com
 2020logs.duckdns.org
 2021dans-yarismasi.com
@@ -266,6 +264,7 @@ dicsordgive.ru
 directmessageviolation.com
 discbrdapp.com
 disccrd.gifts
+disceord.gift
 discord-nitro.ru.com
 discordc.gift
 discordsgift.com
@@ -273,6 +272,7 @@ discqrde.com
 discrods.gift
 disdorsnltro.com
 disocrde.gift
+disocrds.gift
 disordapp.codes
 disordsnltros.gifts
 djscord-alrdrops.com
@@ -309,9 +309,9 @@ flamboyant-curran.52-148-188-66.plesk.page
 flutter-covid19.firebaseio.com
 focused-swirles.34-125-197-109.plesk.page
 forex-danismanlik.ml
+form-to-moderator.com
 formcopyrightviolation.ga
 formredirect.ml
-form-to-moderator.com
 g0sulugl.ru
 g0susiugi.ru
 g0susligi.ru
@@ -601,6 +601,7 @@ hellyaaa.com
 help-accountverify.com
 help-appealsupportcenter.ml
 help-bluebadge.com
+help-for-ukraine.eu
 help-form-live.ml
 help-formsupportcenters.ml
 help-media.com
@@ -611,7 +612,6 @@ helpbusinessportal.ml
 helpcenter-verify.com
 helpcontactservicebusiness.com
 helpformediaportal.com
-help-for-ukraine.eu
 helponactives.ml
 helpportal-feedback.com
 helpserviceforbusines.com
@@ -678,6 +678,7 @@ istismaradur.org
 istismarahayirr.org
 jobsamericanairline.com
 jocoly.esvnpe.com
+jointhehypesquad-eventsteam.com
 jolly-keldysh.34-125-197-109.plesk.page
 kadin-istismarinadurde.net
 kadina-siddetedurde.com
@@ -725,6 +726,7 @@ mail-e9eredelivery.com
 mapadocoronavirus.com
 mastersmshizmetiniz.ml
 mdansikayetimvar.com
+me2.do
 media-fbook.com
 media-line-feedbacks.com
 media-systemservice.com
@@ -807,6 +809,7 @@ sohbetlerimiz-cok-sicak.ml
 sohbetlerimiz-sicak.ml
 sondakka.cf
 spiffcoin.net
+steamcommunitvs.com
 steamcommunvty.com
 steamcomnnulty.com
 stearncomminuty.ru
@@ -911,6 +914,7 @@ webmail.rootyigit.com
 wgosuslugi.ru
 winskull.com
 wonderful-carver.52-229-21-156.plesk.page
+wsetransport.com
 wuhancoronavirustracker-693c1.firebaseio.com
 www-gos-uslugi.ru
 www-gosuslugi-certificat.ru
@@ -1039,6 +1043,3 @@ youareanidiot.cc
 youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 zttmct-tlemp.web.app
-disocrds.gift
-steamcommunitvs.com
-disceord.gift


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
http://jointhehypesquad-eventsteam.com/login/index.php

## Related external source
https://urlscan.io/result/6343526b-1f53-4d03-98e7-a24ba5e6e288

## Describe the issue
This is running a phishing attack against **Discord**. The website displays a fake login form to gather Discord account credentials. Specifically, it targets the HypeSquad events.

### Screenshot
![urlscan](https://urlscan.io/screenshots/6343526b-1f53-4d03-98e7-a24ba5e6e288.png)