### PR TITLE
Addition of phishing domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1049,3 +1049,4 @@ youareanidiot.cc
 youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 zttmct-tlemp.web.app
+subscription-moderating.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
subscription-moderating.com

## Related external source
https://www.virustotal.com/gui/url/1b75266b0ff14247d401b9b982dcbf31cb0364f26ff982665214ded867267cc8?nocache=1

## Describe the issue
Phishing domain, I believe that it might be a discord token grabber or a "front" for aforementioned token grabbing

### Screenshot
[!VirusTotalScreenshot](https://i.imgur.com/BgaE5Gj.png)

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
