### PR TITLE
Update add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1055,3 +1055,4 @@ youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 zttmct-tlemp.web.app
 become-hype.com
+discordiairdrop.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
Added discordiairdrop.com found on discord used to get unauthorized access to users accounts.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
Bad people getting access to others discord accounts thinking they are getting free nitro, when in reality, their credit card (if present) will be used to buy gifted nitro which the bad people use.  


### Screenshot

<details><summary>Click to expand</summary>

![Screenshot from discord](https://cdn.discordapp.com/attachments/699935392295550988/965993193659314277/30B1206B-151C-4CE1-B574-C81618BEF3ED.png)  

</details>
