### PR TITLE
Update add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1055,3 +1055,4 @@ youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 zttmct-tlemp.web.app
 become-hype.com
+boggecl.finance


### PR DESCRIPTION
## Describe the issue

Fake phishing website imitates popular DeFi service. Steals the crypto wallet's credentials after the user connects with their Metamask extension.


