### PR TITLE
Update add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -277,6 +277,7 @@ disocrds.gift
 disordapp.codes
 disordsnltros.gifts
 djscord-alrdrops.com
+djscordiairdrop.com
 dl1-gosuslugi.ru
 dlscord.shop
 dlscordsteami.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:

djscordiairdrop.com

## Related external source
This is a possible alias for #144.

## Describe the issue
Quoting from #144:

Bad people getting access to others discord accounts thinking they are getting free nitro, when in reality, their credit card (if present) will be used to buy gifted nitro which the bad people use.

### Screenshot
The discord message containing the phishing link was already manually deleted.

<details><summary>Click to expand</summary>
</details>
