### PR TITLE
Whitelist `da.gd` in `falsepositive.list`

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -7,3 +7,4 @@ steamcommynitly.com
 satrazsafe.cf
 severanec-traffci-jaes.com
 sakthivel.com
+da.gd


### PR DESCRIPTION
It's an URL shortener that usually got false-positive result.

See reference:
- https://github.com/PeterDaveHello/url-shorteners/blob/4b888d1b2a4b16f883effa2867bfa48b36756c84/list#L102
- https://github.com/PeterDaveHello/url-shorteners/commit/2f8aae7ffa32ce3e13c87882d86c4baf28ee83b0#diff-a330395cc0a53ad1207736546afff4735940937564bbf75ce1edad40780d9139R102

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->


## Impersonated domain
<!-- Required. Use Back ticks. -->


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
