### PR TITLE
add main06866f98-united-domains.karrke.com.au + aliases

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1069,3 +1069,6 @@ dofusevents.com
 www-dofus-touch.com
 www-dofus-touch.com.au
 main.digitalatcopy.com
+main06866f98-united-domains.karrke.com.au
+redi.lavorazioni-inox.it
+redi.digitalatcopy.it

--- a/add-link
+++ b/add-link
@@ -171,3 +171,6 @@ https://actualiteitscheck.com/
 https://main.digitalatcopy.com/ugde/
 https://main.digitalatcopy.com/united/
 https://main.digitalatcopy.com/ventra/
+https://main06866f98-united-domains.karrke.com.au/ventra/
+https://main06866f98-united-domains.karrke.com.au/ugde/
+https://main06866f98-united-domains.karrke.com.au/united/


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
https://main06866f98-united-domains.karrke.com.au/ugde/
https://main06866f98-united-domains.karrke.com.au/united/
https://main06866f98-united-domains.karrke.com.au/ventra/

## Impersonated domain
https://united-domains.de/
https://ventraip.com.au/

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
Page impersonate client interface of the ISPs and phish for CC details


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>
[ugde](https://user-images.githubusercontent.com/7316652/194865527-83d4bac4-5411-4c3b-b189-4284ac07c1d8.png)

[ventra](https://user-images.githubusercontent.com/7316652/194865628-c3160cc5-2f26-4a3b-8b1e-ee56b24f8639.png)
</details>
