### PR TITLE
Add aliexpress.us to false positve

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -10,3 +10,4 @@ sakthivel.com
 da.gd
 www.secure-servicesmt.storyshop.in
 androidauthority.com
+aliexpress.us


### PR DESCRIPTION
ISSUE: https://github.com/mitchellkrogza/Phishing.Database/issues/373
aliexpress.us is not listed in Phishtank or OpenPhish

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->


## Impersonated domain
<!-- Required. Use Back ticks. -->


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
This is a false positive. aliexpress.us is not listed in Phishtank or Openphish and it has the same certificate as aliexpress.com


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
