### PR TITLE
Remove magloft.com

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -11,3 +11,4 @@ da.gd
 www.secure-servicesmt.storyshop.in
 androidauthority.com
 aliexpress.us
+magloft.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
```
www.magloft.com/article/com.magloft.magazine.15185/177970/
```

## Impersonated domain
<!-- Required. Use Back ticks. -->
```
onedrive.com
```

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
```
https://www.virustotal.com/gui/domain/www.magloft.com
https://verdict.valkyrie.comodo.com/url/domain/result?domain=magloft.com
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
A user has create a phishing page which was hosted on our server. We have deleted the page and user.

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
