### PR TITLE
Added fake pc cleaner page

### DIFF
--- a/add-link
+++ b/add-link
@@ -177,3 +177,4 @@ https://main06866f98-united-domains.karrke.com.au/ventra/
 https://main06866f98-united-domains.karrke.com.au/ugde/
 https://main06866f98-united-domains.karrke.com.au/united/
 https://luisianos.myshopify.com/61905436832/checkouts/e5acdea0f6e079b9efb5e64e7988d586?channel=buy_button
+http://www.pcdecrapifier.net/


### PR DESCRIPTION
Page promoting a fake PC cleaner, inviting the user to download malicious software.

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
`http://www.pcdecrapifier.net/`
## Impersonated domain
<!-- Required. Use Back ticks. -->
`It impersonates PC cleaner software like CC cleaner, best observed in the Facebook post where it is being ACTIVELY distributed through ads`
## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
`https://www.facebook.com/pcdecrapifier.net/`
`https://www.facebook.com/peterskatebmxinline/`
## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
`Recently I've been seing a lot of ads in Facebook, using the trick of impersonating a legitimate application and inviting users to download it, even though the actual download is malicious software. This should be considered as phishing too, right?`
### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here
**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->
<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/117121062/199107609-b81cb377-4bd4-4372-82a5-1fdb4707525a.png)

![image](https://user-images.githubusercontent.com/117121062/199107662-99e0b9da-3b52-4167-8c49-3fbf414dc197.png)

</details>
