### PR TITLE
add-domain: fake pc cleaner

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -769,6 +769,7 @@ optimistic-wright.34-125-197-109.plesk.page
 ozzon-mobi-age.com
 paketleme-ekisajansi.org
 park-hotel-sochi.com
+pcdecrapifier.net
 pdfkinghub.xyz
 peaceful-carson.34-125-197-109.plesk.page
 peaceful-joliot.45-136-204-40.plesk.page


### PR DESCRIPTION
From a submission I did before in the wrong file. Now it's where it should be.

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
`pcdecrapifier.net`
## Impersonated domain
<!-- Required. Use Back ticks. -->
`It impersonates PC cleaner software like CC cleaner, best observed in the Facebook post where it is being ACTIVELY distributed through ads`

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
`https://www.facebook.com/pcdecrapifier.net`
`https://www.facebook.com/peterskatebmxinline/`
## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
`Recently I've been seing a lot of ads in Facebook, using the trick of impersonating a legitimate application and inviting users to download it, even though the actual download is malicious software. This should be considered as some kind of phishing too, right?`

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/117121062/199119251-3ed32fcd-6716-4ded-9661-3422ec561837.png)

![image](https://user-images.githubusercontent.com/117121062/199119282-47e41b32-11eb-49be-9381-aff2ef588808.png)

</details>
