### PR TITLE
add-domain nftcomofficial.xyz

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -755,6 +755,7 @@ moscow-gosuslugi.online
 naughty-faraday.34-125-197-109.plesk.page
 new-photo-contest.ml
 newvity.com
+nftcomofficial.xyz
 nice-curran.34-125-197-109.plesk.page
 nparalisk.com
 ns2.brave-ramanujan.34-125-197-109.plesk.page

--- a/add-domain
+++ b/add-domain
@@ -755,6 +755,7 @@ moscow-gosuslugi.online
 naughty-faraday.34-125-197-109.plesk.page
 new-photo-contest.ml
 newvity.com
+nftcomofficial.to-freemint.com
 nftcomofficial.xyz
 nice-curran.34-125-197-109.plesk.page
 nparalisk.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
`nftcomofficial.xyz`
`nftcomofficial.to-freemint.com`


## Impersonated domain
`nft.com`


## Related external source


## Describe the issue
Domain is attempting to steal assets from crypto wallets


### Screenshot

<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/2998891/200877574-d239c460-34ff-42f7-adaa-9637460332cd.png)

![image](https://user-images.githubusercontent.com/2998891/200877666-68dc57a1-9fda-454f-8819-4a8cc3f38627.png)

</details>
