### PR TITLE
Added a fake NFT download site

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -800,6 +800,7 @@ redirect-bussines.cf
 restore637908-coinbase-us.web.app
 right-community-line.cf
 rights-terms-team.com
+rinanft.com
 roblox.com.af
 rootyigit.com
 rxcovid.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
`rinanft.com`

## Impersonated domain
<!-- Required. Use Back ticks. -->
`gigaland.io` (kinda, it is a template)

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
The page lures the user to download a malicious RAR with malware, faking it to be a NFT. 

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

![image](https://user-images.githubusercontent.com/117121062/205167135-c148e915-c697-4acc-82e2-bd0752b7ebc8.png)

<details><summary>Click to expand</summary>


</details>
