### PR TITLE
Add streamrcoin.com phishing domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1082,3 +1082,4 @@ dofus-mmorpg.com
 xn--www-ofus-touch-j1b.com
 stearnconmunity.net
 dofuspourlesnoobs.fr
+streamrcoin.com


### PR DESCRIPTION
Add streamrcoin.com phishing site

## Domain/URL/IP(s) where you have found the Phishing:
`https://discord.gg/gZAm8P7hK8`

## Impersonated domain
`streamr.network`

## Related external source
https://discord.gg/gZAm8P7hK8

## Describe the issue
A Streamr team member (marketing executive) had a session token for Discord stolen through a malicious bookmarklet (fake Mee6 site), after which the hacker started posting fake Streamr airdrop messages from his Discord account. The hacker also installed a webhook that kept posting the scam message through various channels and group Discord DMs.

The scam messages included a link to a fake airdrop phishing site (the domain in question: streamrcoin.com), where victims essentially gave the hacker access to their wallets.

At least 23K USD worth of tokens were stolen although the issue was caught and dealt with immediately.