### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -15,3 +15,4 @@ magloft.com
 forms.office.com
 share.hsforms.com
 denisemortati.com
+stats.sender.net


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
stats.sender.net


## Impersonated domain
btinternet.com


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
This subdomain is used by users of our email marketing software for statistics collection, such as opened and clicked emails, and also hosting opt-in subscription forms. We removed the form used for phishing, and also implemented additional safeguards to prevent this sort of abuse.


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
