### PR TITLE
Add steamcommuneuteui.com (Steam) phishing site

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1086,3 +1086,4 @@ stearnconmunity.net
 dofuspourlesnoobs.fr
 ordersdetail.org
 streamrcoin.com
+steamcommuneuteui.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
`https://steamcommuneuteui.com/0867137fsml1423kfs`


## Impersonated domain
`https://steamcommunity.com`


## Related external source
Found in a steam message an attacker sent

## Describe the issue
This site is a phishing attempt at stealing [Steam](https://store.steampowered.com/) login credentials. This is similar to https://github.com/mitchellkrogza/phishing/pull/199.


### Screenshot
<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/2461562/225420630-cc09b96f-a7b8-4aa0-91eb-daf1ed439d04.png)

</details>
