### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -23,3 +23,4 @@ stats.sender.net
 app.aave.com
 aave.com
 ipfs.io
+freyapos.com


### PR DESCRIPTION
**Domains or links**
https://freyapos.com

**More Information**

1. Website was hacked Yes
3. Incorrectly marked as Phishing on Phishtank or OpenPhish? The webmaster cleaned and secured the website.

**Have you requested removal from other sources?** Fortinet - removed
G-Data - requested
VIPRE - requested
alphaMountain.ai - requested
CyRadar - requested
Phishing Database - I don't know where to ask, please help me

## Domain/URL/IP(s) where you have found the Phishing:
<!-- https://freyapos.com/lake/General2 -->
<!-- https://freyapos.com/wpcontent/General2 -->
<!-- https://freyapos.com/knel/General2 -->
<!-- https://freyapos.com/freyaposs/General2 -->


## Impersonated domain
<!-- Required. Use Back ticks. -->


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
The webmaster cleaned and secured the website.
Please help me and remove from the blacklist the registration for the website: freyapos.com


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
