### PR TITLE
Remove false positive entry for https://vitalounge.com/

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -28,3 +28,4 @@ indcomleasing.com
 www.indcomleasing.com
 portal.indcomleasing.com
 westandsons.co.nz
+vitalounge.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
Domain:- https://vitalounge.com/


## Describe the issue
The issue is that some Internet service providers are blocking vitalounge.com domain due to it being marked as a phishing risk. not all ISPs are blocking the domain, so some clients and users are reporting that the site is not accessible, while others can access the site just fine.



**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
