### PR TITLE
Add ftp.jaist.ac.jp in falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -28,3 +28,4 @@ indcomleasing.com
 www.indcomleasing.com
 portal.indcomleasing.com
 westandsons.co.nz
+ftp.jaist.ac.jp


### PR DESCRIPTION
ftp.jaist.ac.jp is a renowned open-source mirror site, hosting a wide range of projects including but not limited to CPAN, CTAN, GNU, Linux, BSD, and Apache.

It serves as a reliable resource for developers and open-source enthusiasts, users, providing quick and easy access to various software packages and projects.

Not sure why, but it's listed here now: https://github.com/mitchellkrogza/Phishing.Database

Reference:
- https://github.com/mitchellkrogza/Phishing.Database/issues/553
