### PR TITLE
Add discordstatus.com to false-positive

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -29,3 +29,4 @@ www.indcomleasing.com
 portal.indcomleasing.com
 westandsons.co.nz
 ftp.jaist.ac.jp
+discordstatus.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
None. This is a false-positive

## Impersonated domain
<!-- Required. Use Back ticks. -->
\-

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
The domain discordstatus.com is treated as a positive in this Database according to the API that uses it, while it is in fact the official domain used for Discord's status.

This will solve https://github.com/mitchellkrogza/Phishing.Database/issues/570 hopefully.

### Screenshot
