### PR TITLE
False-Positive added: sparkasse-kl.de

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -32,3 +32,4 @@ ftp.jaist.ac.jp
 discordstatus.com
 outlook.live.com
 lp.vp4.me
+sparkasse-kl.de


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
`https://www.virustotal.com/`


## Impersonated domain
`sparkasse-kl.de`

## Describe the issue
False-Positive on the domain of Sparkasse Kaiserslautern

### Screenshot

<img width="1210" alt="Bildschirmfoto 2023-06-16 um 15 01 12" src="https://github.com/mitchellkrogza/phishing/assets/7754638/cc84863d-97e4-4015-8091-69154ffcf9bc"/>
