### PR TITLE
Added false positive cognitivzen.com to the falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -33,3 +33,4 @@ discordstatus.com
 outlook.live.com
 lp.vp4.me
 enovation.ie
+cognitivzen.com


### PR DESCRIPTION
added cognitivzen.com to the list of falsepositives

## Describe the issue
We created a wordpress version of our site to be able to add new pages and data dynamically. But it got hacked and we reverted to our old website after cleaning up the wordpress website and rotating some keys. There is no phishing content on our website and it doesn't have any deceptive content.
