### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -34,3 +34,4 @@ outlook.live.com
 lp.vp4.me
 enovation.ie
 cognitivzen.com
+barclays.investcloud.com


### PR DESCRIPTION
This is an InvestCloud hosted client subdomain for Barclays on investcloud.com.

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
N/A - NOT Phishing

## Impersonated domain
<!-- Required. Use Back ticks. -->
N/A - NOT impersonated

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->

## Describe the issue
VirusTotal shows Phishing Database is falsely listing a subdomain of investcloud.com as phishing.

InvestCloud hosts the site barclays.investcloud.com for Barclays on the investcloud.com domain. 

This URL is not a phishing site. This is a client login page for an InvestCloud client and therefore is hosted as a subdomain of InvestCloud.com. 

Please clear the erroneous report ASAP.


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->
<img width="647" alt="Screenshot 2023-08-29 at 3 58 10 PM" src="https://github.com/mitchellkrogza/phishing/assets/85857476/dc746e60-7d24-46ae-9d31-c1e5fd2b74b9">

<details><summary>Click to expand</summary>


</details>
