### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -32,3 +32,4 @@ cognitivzen.com
 trustmary.com
 form.trustmary.com
 clover.co.jp
+pitch.com


### PR DESCRIPTION
**Domains or links**
pitch.com

**More Information**
How did you discover your web site or domain was listed here? Found it on virustotal.com

**Have you requested removal from other sources?** CRDF - removal was approved

**Additional context**

Pitch is a presentation platform that allows users to publish content on the web. As such, we are vulnerable to abuse by users.

The security of all Pitch users is at the top of our minds, and we are aware of a recent effort to abuse Pitch for phishing. 

We resolved the issue and invested a lot in automation of content scanning and blocking. We believe we solved the recent issue.

Among the measures taken are:

- We integrated multiple tools and services that scan each Pitch public slide/URL for phishing and other abuse. In doubt, our tooling automatically blocks suspicious content.
- We added multiple tools that allow users to report suspicious content.
- We are manually scanning Pitch for suspicious content.

We would appreciate a fast merge and removal from the list, as many innocent users are currently affected.

Happy to provide any other details privately at tom@pitch.io.

