### PR TITLE
Update falsepositive_regex.list

### DIFF
--- a/falsepositive_regex.list
+++ b/falsepositive_regex.list
@@ -2,3 +2,4 @@
 nvidia.com
 rtu.lv
 vuagame.store
+campaign-statistics.com


### PR DESCRIPTION
## Describe the issue
This domain is used by users of our email marketing platform (Sender.net) to track email statistics, such as link clicks, opens, unsubscribes and so on - it's not a phishing site.

There was an incident more than a month ago, where one customer's account was compromised, and used to send DHL phish emails.
But the incident was resolved within a couple of hours, and all URLs disabled.
