### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -34,3 +34,4 @@ form.trustmary.com
 clover.co.jp
 pitch.com
 widget.trustmary.com
+online1.snapsurveys.com


### PR DESCRIPTION
Please list any domains and links listed here which you believe are a false positive. https://online1.snapsurveys.com/


More Information
How did you discover your web site or domain was listed here? Via VirusTotal.com

Have you requested removal from other sources?
We've been removed from Virgin Websafe, Sky Shield, Vipre & Abusix. This is the only platform that is yet to de-list us.

Many thanks.
