### PR TITLE
Update add-link with ChatGPT 5

### DIFF
--- a/add-link
+++ b/add-link
@@ -59,3 +59,5 @@ https://pbrise.com/log/form/
 http://pilatesboutique.com.au/css/commlog/
 https://knowing-merciful-toaster.glitch.me/polkghd.html
 https://s3.ap-south-1.amazonaws.com/bilderwerkstatt-wetterau/bilderwerkstatt-wetterau.html
+https://s.id/newgpt5
+


### PR DESCRIPTION
Added some ChatGPT fake

## Domain/URL/IP(s) where you have found the Phishing:
`https://s.id/newgpt5`


## Impersonated domain
`https://chat.openai.com`

## Describe the issue

It says a new version of ChatGPT, but instead of some kind of virus or scam. Used in Facebook Ads.


### Screenshot

<details><summary>Click to expand</summary>

<img width="626" alt="image" src="https://github.com/mitchellkrogza/phishing/assets/23121787/7fe3668a-ca38-43bb-b0cd-a3f6e713b6c8">

</details>
