### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -35,3 +35,4 @@ clover.co.jp
 pitch.com
 widget.trustmary.com
 online1.snapsurveys.com
+weareindy.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
https://www.virustotal.com/gui/url/e1d638a693ae6e2ff909fb1caaa9cbc12a98655e824f25cfaf7d02bcc6870b75?nocache=1

## Describe the issue
Our domain was marked as phishing due to some published bad forms that were already deleted and additional security measures were applied. Few other vendors already approved our claim (CRDF, CyRadar, Seclookup, Criminal IP).
