### PR TITLE
Add steamcommunitc.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -310,6 +310,7 @@ www-dofus-touch.com
 dofus-mmorpg.com
 xn--www-ofus-touch-j1b.com
 stearnconmunity.net
+steamcommunitc.com
 dofuspourlesnoobs.fr
 tokopb.com
 kuispb.com


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
- `steamcommunitc.com`
- `https://steamcommunitc.com/gift/7838648928762002`


## Impersonated domain
- `https://steamcommunity.com/login/home`


## Related external source
- Detention counts 3/40 on URLVoid: `https://www.urlvoid.com/scan/steamcommunitc.com/`
- Malicious URL detected by Netcraft: `https://sitereport.netcraft.com/?url=http://steamcommunitc.com`
- Added to Discord-AntiScam/scam-links : https://github.com/Discord-AntiScam/scam-links/commit/34624ef8d9b05331bb8faf6db39c4e5d26392d0d

## Describe the issue
Impersonates Steam login page. Used by Discord account hackers


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![изображение](https://github.com/mitchellkrogza/phishing/assets/37241775/1394a25a-2dd6-4c35-834f-bd0150efcf6c)


</details>
