### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -37,3 +37,4 @@ voicemod.net
 westandsons.co.nz
 zenodo.org
 aliexpress.us
+degree37.io


### PR DESCRIPTION
I have created an issue as well and as per your suggestion creating request to you

Domains or links
Please list any domains and links listed here which you believe are a false positive.

degree37.io

More Information
How did you discover your website or domain was listed here?

Checked on totalvirus.com

Additional context
Our website is a blood donor website it has been compromised before and after that, we have cleared that and imposed all the security on it.

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->


## Impersonated domain
<!-- Required. Use Back ticks. -->


## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
