### PR TITLE
Update add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -330,4 +330,7 @@ coronavirus.zone
 documents-download-almeida-3d331c.netlify.app
 rcubebit.bitbucket.io
 wsetransport.com
+www.moscow-post.su
 kyc-bltflyer.web.app
+moscow-post.su
+harborohe.moscow-post.su


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
bing.com ads (phishing ad already expired)


## Impersonated domain
harborone.com

## Describe the issue
On the 21st, an advertisement was created in Microsoft bing using this domain, if you go with a bing.com refferer and a resident USA ip address, a phishing page was opened

## Related external source
Hosted on IP: 185.71.67.60
https://www.virustotal.com/gui/ip-address/185.71.67.60
virustotal.com/gui/domain/moscow-post.su/detection
reports.adguard.com/en/moscow-post.su/report.html
talosintelligence.com/reputation_center/lookup?search=moscow-post.su
otx.alienvault.com/indicator/domain/moscow-post.su
safeweb.norton.com/report/show?url=moscow-post.su
already blocked by OpenDNS , malwarebytes, Daniel Cid, and others

### Screenshots
![Evidence](https://www.antiphish.org/submission/files/d114affbcd326f1da576b24c71f22bbc0e98cc4df3c8e3782791ef9e3b35d645.png) 



![Source of phishing attack](https://www.antiphish.org/submission/files/e130045667427584e321bd8d199e7616e55ffe07736ef143b3b9a0558d685f7d.png)




