### PR TITLE
Update add-link

### DIFF
--- a/add-link
+++ b/add-link
@@ -1,3 +1,4 @@
+https://cloudflare-ipfs.com/ipfs/bafybeidomtj2eipjnjo3wwwcoryt4pdcahssf56v523hdy2apdk663e2me/boilrice.htm
 http://pilatesboutique.com.au/css/commlog/
 https://storageapi.fleek.co/9b907c30-dca7-4129-b75f-8cb44e5b5e06-bucket/index.html
 https://storageapi.fleek.co/1feb1999-9414-490f-9fd9-660d6a626ce1-bucket/encrypttwopentttmrrmukart.html


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
`https://cloudflare-ipfs.com/ipfs/bafybeidomtj2eipjnjo3wwwcoryt4pdcahssf56v523hdy2apdk663e2me/boilrice.htm#info@technikamateur.de`


## Impersonated domain
Generic Webmail. Maybe roundcube? Domain impersonates `cloudflare.com`


## Describe the issue
They trying to get your email account and password. If the link is send via email, they attach a `#info@test.com`, so the email is prefilled.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
![Screenshot_20240111-085557](https://github.com/mitchellkrogza/phishing/assets/18737267/6fc1b806-1436-44ec-b690-b9c42b047323)

