### PR TITLE
Add pichinchamasbeneficios.pe in your false positive list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -41,3 +41,4 @@ aliexpress.us
 degree37.io
 forms.onepagecrm.com
 osky.com.au
+pichinchamasbeneficios.pe

--- a/falsepositive_regex.list
+++ b/falsepositive_regex.list
@@ -3,3 +3,4 @@ campaign-statistics.com
 nvidia.com
 rtu.lv
 vuagame.store
+pichinchamasbeneficios.pe/PichinchaPeWeb/login


### PR DESCRIPTION
Linked to https://github.com/mitchellkrogza/Phishing.Database/issues/813

This site that belongs to Banco Pichincha Peru, you are categorizing this site as PHISHING. Please review the case and not categorize it as phishing, as this harms the entity. Thank you.

URL VirusTotal: https://www.virustotal.com/gui/url/4b6663d807b0d2d77e5801239ef7685951ff036651f6ab609a1b6d617e7ecdbd

I have a email from a bank employee on the authenticity of the domain:
![image](https://github.com/mitchellkrogza/phishing/assets/106082098/76487531-034d-45ce-9557-609de0e196db)

She says:

_Dear
The bank has the PICHINCHAMASBENEFICIOS.PE page, which has been labeled malicious. The owner of the domain and the SSL certificate associated with that page have been validated as a third-party provider. 
For this reason, we ask for your support with recommendations to improve the reputation of the page, taking into consideration that the administration of the domain and certificate continues to be outsourced by a provider.
Best regards_ 