### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -41,3 +41,4 @@ aliexpress.us
 degree37.io
 forms.onepagecrm.com
 osky.com.au
+claritysecure.claritycrm.com


### PR DESCRIPTION
claritysecure.claritycrm.com is marked by the Phishing database. We want this domain to be cleaned from your side.

## Domain/URL/IP(s) where you have found the Phishing:
claritysecure.claritycrm.com



