### PR TITLE
Update add-wildcard-domain

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -15,3 +15,7 @@ skimswanp.com
 southerninsurs.com
 mhktricks.org
 reltio-apps.com
+wasabiwallet.app
+wasabiwallet.eu
+wasabiwallet.sh
+wasabiwallet.uk


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
```
wasabiwallet.app
wasabiwallet.eu
wasabiwallet.sh
wasabiwallet.uk
```

Note: the `.uk` is currently not in use but is already SEO positioned so I suspect that it's a fallback domain whenever the first ones will go down.

## Impersonated domain
`wasabiwallet.io`

## Describe the issue
I added to the wildcard because Wasabi Wallet also has a blog that is also copied on some phishing websites (such as the `.app`)

Wasabi Wallet is a Bitcoin wallet, on a daily basis we have users that are victims of those scams. It's really hard for us to fight against because SEO is hard for a crypto related website so they always manage to score first on Bing, and because Wasabi Wallet is a privacy related product, and Bing is used by DuckDuckGo.... Many users are victims...

You can verify that `.io` is the correct domain here: https://github.com/zkSNACKs/WalletWasabi and here: https://twitter.com/wasabiwallet
