### PR TITLE
Update add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -335,3 +335,4 @@ kyc-bltflyer.web.app
 moscow-post.su
 harborohe.moscow-post.su
 bitflyer-global.com
+bitflyer.sviluppo.host


### PR DESCRIPTION
phishing

## Domain/URL/IP(s) where you have found the Phishing:
`bitflyer.sviluppo.host`

## Impersonated domain'
`bitflyer.com`

## Describe the issue
Phishing site impersonating Japanese cryptocurrency exchange.
I would like your product(i.e. Virus Total result service) to recognize the malicious site as phishing/malicious to notify potential victims.



## Related external source
Url scan: https://urlscan.io/result/43824ed6-8d08-47f3-996e-43c507e6d2d9/
Virus total: https://www.virustotal.com/gui/url/62f57c4148be6cd339cbbb36529515be7b83cd360d0e803ab04b9cccf35226d4
Official site: https://bitflyer.com/ja-jp/login



### Screenshot
![Screenshot 2024-02-27 at 10 50 57](https://github.com/mitchellkrogza/phishing/assets/154313322/87e708f2-a898-4555-b7e4-bdbb4b67f93b)

![Official_Top](https://github.com/mitchellkrogza/phishing/assets/154313322/94c75e80-f98c-4060-92e0-49908c93ba7c)
![Official_login](https://github.com/mitchellkrogza/phishing/assets/154313322/5dc1a872-fbb2-4291-aff9-c406af24515d)


<details><summary>Click to expand</summary>


</details>
