### PR TITLE
Update falsepositive.list  haproxy-vip.quicksign.fr

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -46,3 +46,4 @@ claritysecure.claritycrm.com
 injective.talis.art
 mailsuite.com
 mailtrack.io
+haproxy-vip.quicksign.fr


### PR DESCRIPTION
PR to remove haproxy-vip.quicksign.fr from phishing database

## Domain/URL/IP(s) where you have found the Phishing:
N/A


## Impersonated domain
N/A


## Describe the issue
Declaration of false positive in https://github.com/mitchellkrogza/Phishing.Database/issues/837


## Related external source
Virustotal on https://www.virustotal.com/gui/domain/quicksign.fr


### Screenshot
N/A

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
