### PR TITLE
lnk.at false positive

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -47,3 +47,5 @@ injective.talis.art
 mailsuite.com
 mailtrack.io
 haproxy-vip.quicksign.fr
+https://lnk.at/jsjssgs
+lnk.at

--- a/falsepositive.list
+++ b/falsepositive.list
@@ -47,5 +47,4 @@ injective.talis.art
 mailsuite.com
 mailtrack.io
 haproxy-vip.quicksign.fr
-https://lnk.at/jsjssgs
 lnk.at


### PR DESCRIPTION
**Domains or links**
https://lnk.at/jsjssgs
lnk.at

**More Information**
How did you discover your web site or domain was listed here?
1. User created an account on our website builder and linked to external phishing page
2. Immediately banned from our platform but listed in virustotal

**Have you requested removal from other sources?**
CRDF: already removed => https://threatcenter.crdf.fr/false_positive.php?ref=20240312805335
Quttera: already removed
Virustotal: request sent, pending reply
Avira: request sent, pending reply