### PR TITLE
sg-autorepondeur.com false positive

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -47,3 +47,4 @@ injective.talis.art
 mailsuite.com
 mailtrack.io
 haproxy-vip.quicksign.fr
+sg-autorepondeur.com


### PR DESCRIPTION
**Domains or links**
https://sg-autorepondeur.com/public/index.php
sg-autorepondeur.com

**More Information**
How did you discover your web site or domain was listed here?
- Website was listed on virustotal.com :
![image](https://github.com/mitchellkrogza/Phishing.Database/assets/8447165/cbaa8414-80cc-4b1e-a79e-f335874c675c)

**Have you requested removal from other sources?**
We can see here that we successfully removed the domain/URL from 2 sources :
https://www.virustotal.com/gui/url/cdbedc86fbeaa5b73cf3590b013bbba09d4671b66ac02107bfe61559fb8408be
Avira : Already removed
Cluster25 : request sent, pending reply
CRDF : request sent, pending reply
ESET : Already removed
Forcepoint ThreatSeeker : Already removed
Seclookup : request sent, pending reply
VIPRE : Already removed