### PR TITLE
Add euw1.nyl.as to falsepositive list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -65,3 +65,4 @@ mailsuite.com
 mailtrack.io
 haproxy-vip.quicksign.fr
 lnk.at
+euw1.nyl.as


### PR DESCRIPTION
## Domain/URL/IP(s) where you have found the Phishing:
`euw1.nyl.as`

## Describe the issue
euw1.nyl.as is listed on the phishing list, its a subdomain for nyl.as which is a a redirecting/shortening URL service with our APIs.  https://developer.nylas.com/docs/dev-guide/platform/what-is-nyl/. I have attached the URL to our Developer docs.

I have created the issue here with more details; https://github.com/mitchellkrogza/Phishing.Database/issues/851 