### PR TITLE
Add lumberjack link shortener domain to falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -67,4 +67,3 @@ haproxy-vip.quicksign.fr
 lnk.at
 l-k.io
 s.l-k.io
-lumberjack-link.com

--- a/falsepositive.list
+++ b/falsepositive.list
@@ -67,3 +67,4 @@ haproxy-vip.quicksign.fr
 lnk.at
 l-k.io
 s.l-k.io
+lumberjack-link.com

--- a/falsepositive.list
+++ b/falsepositive.list
@@ -65,3 +65,6 @@ mailsuite.com
 mailtrack.io
 haproxy-vip.quicksign.fr
 lnk.at
+l-k.io
+s.l-k.io
+lumberjack-link.com


### PR DESCRIPTION
**Domains or links**

```
https://l-k.io
https://s.l-k.io
```

**More Information**
How did you discover your web site or domain was listed here?
2. Incorrectly marked as Phishing on Phishtank or OpenPhish? No but Incorrectly marked as Phishing on VirusTotal

**Have you requested removal from other sources?**
We request to remove form all other security platform we find in VirusTotal.

**Additional context**
Request to falsepositive and/or whitelist our link-shortener `https://l-k.io`

Dear Phishing Database Team,

I'm reaching out on behalf of LumberjacK Link Shortener, the team behind the `l-k.io` domain. We run a link shortening service, aiming to make web navigation smoother by turning long URLs into short links. It has come to our attention that our domain has been flagged as malicious in your systems. I want to assure you that our primary goal is to enhance user experience on the web while ensuring safety and integrity.

Here's the deal:

- Google Web Risk API: We use this to scan and check the safety of destination links.
- Fraud Detection Algorithms: We've developed our own tech to spot and filter out sketchy or malicious content.
- External Services: We also lean on trusted third parties for an extra layer of scrutiny on the links.

We're all about making the internet a safer place, and we take it seriously. But, let's be real, no system is perfect, and sometimes users might misuse our service for not-so-great purposes. When that happens, we're quick to act, rectify the situation, and beef up our measures.

So, we're kindly asking if you could take another look at our domain's reputation. Any advice or suggestions on how we can up our security game would be greatly appreciated, too. We're here to make things right and to keep the web safe and sound.

Thanks for considering our request. We're ready to provide any additional info or to work closely with you to clear up this misunderstanding.

Best regards,

