### PR TITLE
add theaerie.ca to add-wildcard-domain

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -19,6 +19,7 @@ skimswanp.com
 southerninsurs.com
 steamcommumtiy.com
 sxlph.site
+theaerie.ca
 wasabiwallet.app
 wasabiwallet.eu
 wasabiwallet.sh


### PR DESCRIPTION
theaerie[.]ca is now hosting the kit that was previously on nico[.]sa and before that ajstelecom[.]com[.]mx

## Domain/URL/IP(s) where you have found the Phishing:
<!-- Required. Use Back ticks. -->
```
https://theaerie.ca/M3MyVDByMXQyUTlBNHE=
```

## Impersonated domain
<!-- Required. Use Back ticks. -->
```
https://www.zimbra.com/
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
This (likely recently compromised) site is hosting the phishing kit that was previously active at nico[.]sa, see #366.  Before that the group was using ajstelecom[.]com[.]mx. See https://github.com/mitchellkrogza/phishing/pull/362 https://github.com/mitchellkrogza/phishing/pull/353 and https://github.com/mitchellkrogza/phishing/pull/343 for a recent history of this activity group. The previous host had more than 250 malicious endpoints identified in a two week period. I don't have a facebook account but you will likely be able to find lures and additional URIs there until I can update this submission with additional samples after the search engines have had a chance to recrawl the various social media platforms.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
```
https://urlscan.io/result/300295b9-fadc-421d-a3ef-19539d938b6e/
```

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![image](https://github.com/mitchellkrogza/phishing/assets/108126637/63b6f0f5-a3bd-4002-b369-0fe219217e63)

</details>
