### PR TITLE
add sxlph.club, phsw.site to add-wildcard-domain

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -34,3 +34,5 @@ wasabiwallet.app
 wasabiwallet.eu
 wasabiwallet.sh
 wasabiwallet.uk
+sxlph.club
+phsw.site


### PR DESCRIPTION
I have received a phishing link `globe.sxlph.club/ph`, it's the as the `globe.sxlph.site/tt` that I had reported before. for `globe.phsw.site/tt` page no longer shows the same webpage as the two links but it acts the same as the two links

## Domain/URL/IP(s) where you have found the Phishing:
`SMS`
`Reddit` 


## Impersonated domain
`https://www.globe.com.ph/`


## Describe the issue
`phishing site to scam people to 'redeem rewards' phsw.site has the same whois information as sxlph.site`

## Related external source
https://www.reddit.com/r/Scams/comments/1bp1slj/globe_text_message_phishing_scam/

### Screenshot
<!-- **TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![image](https://github.com/mitchellkrogza/phishing/assets/61625031/5fbee480-d5b3-44fe-a77c-c8ca6ab17ac2)

![image](https://github.com/mitchellkrogza/phishing/assets/61625031/877cb4b7-fdd4-441f-9998-47a196066339)

![image](https://github.com/mitchellkrogza/phishing/assets/61625031/1769eb7a-9258-42ea-9dae-60c2f0756095)

</details>


