### PR TITLE
whitelist false positive domain

### DIFF
--- a/falsepositive_regex.list
+++ b/falsepositive_regex.list
@@ -4,3 +4,4 @@ nvidia.com
 rtu.lv
 surveysparrow.com
 vuagame.store
+idtech.no


### PR DESCRIPTION
Domain was incorrectly classified by CRDF, and other security vendors piled on. CRDF has since reverted their decision. See: https://threatcenter.crdf.fr/false_positive.php?ref=20240411303024

## Phishing Domain/URL/IP(s):
`https://current.aletheia-test.idtech.no/authorization` (false positive)

## Impersonated domain
N/A

## Describe the issue

This url was initially flagged by CRDF 3 months ago but has since been removed from CRDFs database due to being a false positive. It seems you have read info about this URL from CRDF, or via another party which has read from CRDF. In light of CRDFs decision we want to whitelist the url here.

Link to CRDFs decision: https://threatcenter.crdf.fr/false_positive.php?ref=20240411303024

## Related external source
https://threatcenter.crdf.fr/false_positive.php?ref=20240411303024
https://www.virustotal.com/gui/url/164248c4b08e36070dfdbae6a849b4fc079a7e7501ea2015a1922f913c93d016

Closes #873
