### PR TITLE
Update falsepositive.list

### DIFF
--- a/falsepositive.list
+++ b/falsepositive.list
@@ -55,3 +55,4 @@ voicemod.net
 westandsons.co.nz
 zenodo.org
 aliexpress.us
+ethans.link


### PR DESCRIPTION
**Domains or links**
`https://ethans.link`

**More Information**
Two links from the above site are listed in this database which was discovered through Virus Total.

**Have you requested removal from other sources?**
Yes, though this has been done through email/forms to other security vendors discovered through Virus Total, so I do not have links/images to share. Virus Total initially had ~15 vendors that had flagged the site, and that is now down to 4.

**Additional context**
The above site is link shortening/redirecting service that had been used maliciously, but the malicious content been removed and the service locked to prevent further misconduct.