### PR TITLE
Update add-domain `https://login.bitflyer-ja.free.nf`

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -400,3 +400,4 @@ youthful-engelbart.34-125-197-109.plesk.page
 zc11m.csb.app
 zt-za.fr
 zttmct-tlemp.web.app
+login.bitflyer-ja.free.nf


### PR DESCRIPTION
Phishing site of Japanese crypto exchange

## Phishing Domain/URL/IP(s):
`https://login.bitflyer-ja.free.nf`


## Impersonated domain
`bitflyer.com`

## Describe the issue
To whom it may concern,

I am writing to inform you that the following site is phishing.

A scammer has registered the following domain. I would like your product(i.e. Virus Total result service) to recognize the malicious site as phishing/malicious. 

[Phishing site]
`https://login.bitflyer-ja.free.nf`

Best regards,



## Related external source
[Official site]
Https://bitflyer.com/

[Access environment]
Device: PC/iPhone/Android
IP: Japan

[Urlscan]
https://urlscan.io/result/0c14e8c4-7c65-4d6d-995b-99c0f4b5e438/

### Screenshot
![Screenshot 2024-05-27 at 10 06 26](https://github.com/mitchellkrogza/phishing/assets/154313322/577ed4cb-03f6-4470-b591-634a587011

![Official_Top](https://github.com/mitchellkrogza/phishing/assets/154313322/b2502e09-701e-41ec-aefa-4e2af8b2abbc)
e1)

![Official_login](https://github.com/mitchellkrogza/phishing/assets/154313322/68be25cd-924c-46ee-9d3e-76913519e9ed)

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
