### PR TITLE
com-1.xyz

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -67,5 +67,5 @@ fjwamneg.top
 technowide.com.tr
 wasabiwallet.uk
 wisbechguide.uk
-tiktokafrica-ofertas-1.com-1.xyz
+com-1.xyz
 yildirim-firsati.xyz


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://chat-wihatisapp.com-1.xyz/
http://whatsapp-spy.com-1.xyz/
http://netflix.com-1.xyz/
```

## Impersonated domain
<!-- Required. Use Back ticks. -->


## Describe the issue
Rremove tiktock related subdomain and add com-1.xyz to add-wildcard-domain

After taking a second look at #428 I decided to run a query for ```com-1.xyz```, which revealed a history of other phishing related subdomains hosted at the same domain over a period of 6 years.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
```
https://urlscan.io/search/#com-1.xyz
https://urlscan.io/result/1b060847-2601-4a78-b6a1-20fc1a980186/
https://urlscan.io/result/01351ba8-1a25-46b4-a059-d6f5131c573b/
https://urlscan.io/result/0ba94c63-60a4-425d-96db-b5e2d3b83223/

```

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![01351ba8-1a25-46b4-a059-d6f5131c573b](https://github.com/mitchellkrogza/phishing/assets/108126637/0156880d-1e76-4036-8231-9f15c036a359)
![0ba94c63-60a4-425d-96db-b5e2d3b83223](https://github.com/mitchellkrogza/phishing/assets/108126637/6fb92726-1edd-4abe-97f3-19d3c5461e5b)

</details>
