### PR TITLE
Update add-domain mecofficial.com

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -747,3 +747,4 @@ soclaiemx.xyz
 wiflix.xyz
 wiflix.yachts
 coronavirus.zone
+mecofficial.com


### PR DESCRIPTION
mecofficial.com is a clone of mec.ca and is attempting to phish users via facebook.

## Phishing Domain/URL/IP(s):
'mecofficial.com'


## Impersonated domain
'mec.ca'


## Describe the issue
site is a clone of the real site with big discounts, it has been linked to via facebook ads


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>


</details>
