### PR TITLE
added comdirect phising domains

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,3 +1,5 @@
+comd-refresh.com
+comdire24.com
 gosuslugi.agency
 coronavirus.app
 www.coronavirus.app

--- a/add-domain
+++ b/add-domain
@@ -1,5 +1,3 @@
-comd-refresh.com
-comdire24.com
 gosuslugi.agency
 coronavirus.app
 www.coronavirus.app
@@ -42,6 +40,8 @@ bitflyer-global.com
 business-facebook-covid19.com
 cheapcorona.com
 ciel-goshugi.com
+comd-refresh.com
+comdire24.com
 confirm-snet.com
 corona-explained.com
 corona-power.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
`http://comd-refresh.com/` which redirects to `https://comdire24.com/`


## Impersonated domain
`https://www.comdirect.de/`


## Describe the issue
Website tries to get login information of comdirect bank. Urlscan: `https://urlscan.io/result/b5b2d4bb-6096-4ca1-ae9b-6f2c14828561/` shows `Google Safe Browsing: Malicious`

Website is protected by Google captcha. Hence, the scan is incomplete.


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
![signal-2024-08-04-115154](https://github.com/user-attachments/assets/e19ee17d-eb9a-42c6-89c5-988fb3e818f3)


<details><summary>Click to expand</summary>


</details>
