### PR TITLE
add com-trackahc.top to wildcard list

### DIFF
--- a/add-wildcard-domain
+++ b/add-wildcard-domain
@@ -163,6 +163,7 @@ crypto-wave.store
 yildirim-firsati.store
 anjpvv.top
 bkskhcil.top
+com-trackahc.top
 commodityprocess.top
 crypto-wave.top
 darnroughonline.top


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://usps.com-trackahc.top/l/ 
```

## Impersonated domain
<!-- Required. Use Back ticks. -->
```
https://tools.usps.com/go/TrackConfirmAction_input
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
This domain is being used for a USPS smishing campaign.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
```
https://urlscan.io/result/88585569-2bf2-407e-b60c-c7ce004bc616/
```

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

![462540121_449139060956420_1006755931835840211_n](https://github.com/user-attachments/assets/e0802008-fe6b-432d-b633-75cc4e865d55)
![88585569-2bf2-407e-b60c-c7ce004bc616](https://github.com/user-attachments/assets/b1e141e2-741a-4437-9f8f-096ee0617e12)

</details>
