### PR TITLE
Update add-domain with Purolator Canada phishing link

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -1,3 +1,4 @@
+ca-purolator.com
 gosuslugi.agency
 coronavirus.app
 www.coronavirus.app


### PR DESCRIPTION
Add Purolator Canada based phishing domain. I received a text stating I had a package to pickup, despite not having an order with Purolator. The phishing link in full is the bad domain/?UNIQUE_ID . I tested accessing it with Tor but was not able to load any content. This link was received 2023 and is still active, Cloudflare domain registration.

## Phishing Domain/URL/IP(s):
ca-purolator.com


## Impersonated domain
purolator.com

## Describe the issue
The domain attempts to impersonate the real Purolator website. I was unable to load the actual site content over Tor, I want to assume they'll ask for either payment information on "owed duties" or some kind of address information.

At the moment the website does not load and gives a Cloudflare 522 error, so in this case if it's not desired to add an "inactive website", I understand.

### Screenshot

<details><summary>Click to expand</summary>

![Screenshot_20231116-160215_Messaging](https://github.com/user-attachments/assets/0fa558b0-0b67-4e23-841a-c74a71610a38)

</details>
