### PR TITLE
add ɡithub.com to add-domain

### DIFF
--- a/add-domain
+++ b/add-domain
@@ -770,3 +770,5 @@ wiflix.yachts
 coronavirus.zone
 gіthսᖯ.com
 ɡithub.com
+ɡooɡɩe.com
+ɡooɡle.com

--- a/add-domain
+++ b/add-domain
@@ -768,7 +768,6 @@ soclaiemx.xyz
 wiflix.xyz
 wiflix.yachts
 coronavirus.zone
-gіthսᖯ.com
 ɡithub.com
 ɡooɡɩe.com
 ɡooɡle.com

--- a/add-domain
+++ b/add-domain
@@ -772,3 +772,4 @@ gіthսᖯ.com
 ɡithub.com
 ɡooɡɩe.com
 ɡooɡle.com
+gmaiɩ.com

--- a/add-domain
+++ b/add-domain
@@ -768,3 +768,5 @@ soclaiemx.xyz
 wiflix.xyz
 wiflix.yachts
 coronavirus.zone
+gіthսᖯ.com
+ɡithub.com

--- a/add-domain
+++ b/add-domain
@@ -770,5 +770,4 @@ wiflix.yachts
 coronavirus.zone
 ɡithub.com
 ɡooɡɩe.com
-ɡooɡle.com
 gmaiɩ.com

--- a/add-domain
+++ b/add-domain
@@ -772,3 +772,4 @@ coronavirus.zone
 ɡooɡɩe.com
 ɡooɡle.com
 gmaiɩ.com
+раураɩ.com

--- a/add-domain
+++ b/add-domain
@@ -772,4 +772,3 @@ coronavirus.zone
 ɡooɡɩe.com
 ɡooɡle.com
 gmaiɩ.com
-раураɩ.com

--- a/add-domain
+++ b/add-domain
@@ -768,6 +768,6 @@ soclaiemx.xyz
 wiflix.xyz
 wiflix.yachts
 coronavirus.zone
-ɡithub.com
-ɡooɡɩe.com
-gmaiɩ.com
+xn--ooe-8tbc2c.com
+xn--gmai-88b.com
+xn--ithub-qmc.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
`https://ɡithub.com`


## Impersonated domain
`https://github.com`

## Describe the issue
You might be wondering why do I want to add "ɡithub.com"?

The answer is: it's not the real github.com, though they look similar. Still unsure? Try comparing "ɡithub.com" === "github.com" in your browser console—you'll see it returns `false`.

This attack is called `IDN Homograph Attack`. It is a very advanced type of attack – and I plan keep adding relevant **homograph domains** here from now on, so we will help people from being deceived by them.

I used a tool I created, [EvilURL](https://github.com/glaubermagal/evilurl), to analyze the real github.com domain, and I discovered a concerning issue: some registrars allow domains with mixed character sets, enabling bad actors to create domains that look nearly identical to legitimate ones. And this malicious domain "ɡithub.com" is registered and pointing to a malicious website.


**Feel free to follow me on github contribute to EvilURL tool. Stars are welcome.**


## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->
<img width="766" alt="image" src="https://github.com/user-attachments/assets/03b5aea2-2633-481d-863a-aec7815cdc39">
<img width="516" alt="image" src="https://github.com/user-attachments/assets/50545d21-f65f-4256-9d0d-89191d5dc941">

<details><summary>Click to expand</summary>


</details>
