### PR TITLE
add new telegram account phishing link

### DIFF
--- a/add-link
+++ b/add-link
@@ -64,3 +64,4 @@ https://www.manitowocice.com/Media/Manitowocice/robux1.html
 https://www.seo-domain.net/0:gateway:checkout/2999994
 https://s3-poshmark.id829.com/211083758
 https://samsungsecure.com/smartthingsfind.samsung.com/smart-switch
+https://vrum.pics/+xJELB_6H_lEHxFH


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
`https://vrum.pics/+xJELB_6H_lEHxFH`


## Impersonated domain
`https://web.telegram.org/k/`


## Describe the issue
Looks like this URL and its associated domain is used for an ongoing phishing campaign for hijacking telegram accounts.


## Related external source
https://www.virustotal.com/gui/url/62d26eb03aad31db8a2441dfa191df3b46f7f17c6deddaaf361d1b4c30a7696f


### Screenshot

<details><summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/ff7c7837-fc86-4e83-9f49-8e4518185f71)

</details>
