### PR TITLE
Add phishing links

### DIFF
--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -4114,3 +4114,6 @@ https://yeicotjj.github.io/auditoria/continue.html
 https://yonehunqpom.life/zpxd
 https://yuppiiechef.com/account/ű
 https://zmedtipp.live/mnvzx
+https://www.recompenses-dofus.com/fr/
+https://www.recompenses-dofus.com/fr/mmorpg/actualites06/parchemins/succes.php
+https://www.recompenses-dofus.com/


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://www.recompenses-dofus.com/fr/
https://www.recompenses-dofus.com/fr/mmorpg/actualites06/parchemins/succes.php
https://www.recompenses-dofus.com/
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
dofus.com
```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->
The site is clearly being used to spread phishing from dofus.com. Several redirects are being made, from / and /fr/.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
https://urlscan.io/result/0197ffec-711d-75f3-b807-3a91813b5ac4/

### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>
Legitimate:

![legitimate](https://github.com/user-attachments/assets/0a9e7902-4546-4582-aa57-5061033a883b)

Phishing:
![recompenses-dofusDOTcom](https://github.com/user-attachments/assets/b5d8ff20-1375-4c65-821b-c64df74a1cd8)

</details>
