### PR TITLE
Whitelisting apkpure.com

### DIFF
--- a/falsepositives/permanent/domains.list
+++ b/falsepositives/permanent/domains.list
@@ -16,7 +16,6 @@ admin.trustindex.io
 adropofom.com
 aikidofc.com
 airtable.com
-ajax.googleapis.com
 alexalo.com
 aliexpress.us
 amazon.com


### PR DESCRIPTION
Hello, so the domain itself is currently blocked, and seeing as there's already an issue on this from [a while back](https://github.com/Phishing-Database/Phishing.Database/issues/27), opening a pull request here seemed the next best option with the new verifying dns system there. I put it in the all.list as this domain; 'm.apkpure.com' is also implicated.