### PR TITLE
Add 2famondatory.com and red15524.bookyourbooknow.com to domains.list

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,5 @@
+2famondatory.com
+red15524.bookyourbooknow.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
2famondatory.com
red15524.bookyourbooknow.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
trustwallet.com
```

## Describe the issue
This is similar to https://github.com/Phishing-Database/phishing/pull/1112

A new phishing email related to this case has a link to `https://red15524.bookyourbooknow.com/book` that redirects via JavaScript to `https://truntwallet.2famondatory.com/taBLiNZ-kphE78e/index.html`

## Related external source
https://phishtank.org/phish_detail.php?phish_id=9329286
https://phishtank.org/phish_detail.php?phish_id=9329739
https://phishtank.org/phish_detail.php?phish_id=9329740
https://phishtank.org/phish_detail.php?phish_id=9329751
https://phishtank.org/phish_detail.php?phish_id=9329754
https://urlscan.io/search/#page.domain%3Atruntwallet.2famondatory.com
https://urlscan.io/result/019c1d61-6728-74f8-a0ff-1c80b52a97d0/

### Screenshot

<img width="759" height="44" alt="image" src="https://github.com/user-attachments/assets/9508b59d-3ffb-47e5-9627-1a0deafc0c64" />

<img width="1495" height="1023" alt="image" src="https://github.com/user-attachments/assets/bc9958de-3edd-4b43-8324-4d706fcf3b17" />
