### PR TITLE
Block tj.16gift.com being used as tracker for various phishing sites

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+tj.16gift.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -1,3 +1,4 @@
+https://tj.16gift.com/js/script.js
 http://147.45.44.131/infopage/resafh7.exe
 http://147.45.44.131/infopage/vgqvs.bat
 http://147.45.44.131/infopage/vtqrai.exe


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
tj.16gift.com
https://tj.16gift.com/js/script.js
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```

```

## Describe the issue
This is seen in the wild as a tracker for various phishing websites, specifically related to https://github.com/Phishing-Database/phishing/pull/1145

<img width="1324" height="1031" alt="Image" src="https://github.com/user-attachments/assets/91efd3a7-a87e-4908-a50b-e359028bcfc7" />

The subdomain `tj.16gift.com` serves a tracking script via `https://tj.16gift.com/js/script.js` which is a Plausible Analytics script.

<img width="1669" height="187" alt="Image" src="https://github.com/user-attachments/assets/de61e3a1-5435-44bf-9f44-3d94243e79c9" />

The subdomain actively tracks data as shown in the following POST data.

<img width="1470" height="346" alt="Image" src="https://github.com/user-attachments/assets/99956f93-4d73-4219-8084-cbc7c47534bb" />

<img width="1473" height="350" alt="Image" src="https://github.com/user-attachments/assets/dc69dc42-6a41-4247-af1d-c8e9f219ac28" />


## Related external source
https://github.com/hagezi/dns-blocklists/issues/10071
https://github.com/Phishing-Database/phishing/pull/1145
https://github.com/hagezi/dns-blocklists/issues/10046