### PR TITLE
Add polydistrib.com to domains.wildcard.list

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,4 @@
+polydistrib.com
 123pan.cn
 13afx.top
 17fdg.xyz


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
polydistrib.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
polymarket.com
```

## Describe the issue
A phishing email was received with a link to `https://market.polydistrib.com/` that spoofs `polymarket.com`. The root domain `polydistrib.com` is also accessible.

<img width="683" height="973" alt="Screenshot_20260602_221742" src="https://github.com/user-attachments/assets/b2039cbf-5288-4fa5-af0c-71824143ef3a" />
<img width="1651" height="1027" alt="Screenshot_20260602_221920" src="https://github.com/user-attachments/assets/01dd142f-891c-48cc-994c-8a3f925b0509" />



## Related external source
https://phishtank.org/phish_detail.php?phish_id=9441186
https://phishtank.org/phish_detail.php?phish_id=9441187