### PR TITLE
Block Tornado Cash Phishing Sites

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,9 @@
+tornado-cash.link
+tornadocash.net
+tornadocash.ws
+tornadoeth.cash
+tornadopro.cash
+tornadoproxy.eth.limo
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
tornado-cash.link
tornadocash.net
tornadocash.ws
tornadoeth.cash
tornadopro.cash
tornadoproxy.eth.limo
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
tornadocash.eth.limo
```

## Describe the issue
These domains are officially declared by the Tornado Cash Telegram group as phishing sites and are still online.

<img width="1233" height="1002" alt="Screenshot_20260622_185616" src="https://github.com/user-attachments/assets/d916a2a4-1e9c-46d1-9c0a-e4f6c0912679" />

## Related external source
https://github.com/Phishing-Database/phishing/pull/1197
https://github.com/hagezi/dns-blocklists/issues/10605