### PR TITLE
Block iCloud Phishing Links

### DIFF
--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,6 @@
+strategicreflect.com
+improve-ur-finance.com
+securedenvironment.com
 123pan.cn
 13afx.top
 17fdg.xyz

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -1,3 +1,5 @@
+https://s3.us-east-1.amazonaws.com/cldus.ab/uscld.html
+https://s3.us-east-1.amazonaws.com/cldus.ab/unsubcld.html
 http://147.45.44.131/infopage/resafh7.exe
 http://147.45.44.131/infopage/vgqvs.bat
 http://147.45.44.131/infopage/vtqrai.exe


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://s3.us-east-1.amazonaws.com/cldus.ab/uscld.html
https://s3.us-east-1.amazonaws.com/cldus.ab/unsubcld.html
strategicreflect.com
improve-ur-finance.com
securedenvironment.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
icloud.com
https://www.apple.com/icloud/
```

## Describe the issue
A phishing email was received spoofing an iCloud notification. The links go to `https://s3.us-east-1.amazonaws.com/cldus.ab/uscld.html` and `https://s3.us-east-1.amazonaws.com/cldus.ab/unsubcld.html`.

<img width="1151" height="917" alt="image" src="https://github.com/user-attachments/assets/b23b517e-4764-4881-bc5b-1a59574ce68b" />

The page contains a JavaScript redirection code to `https://www.strategicreflect.com/5P2W1PG/29935QRJ/?sub1=abdo&sub2=22`

<img width="898" height="197" alt="image" src="https://github.com/user-attachments/assets/1a45d615-1c78-49ac-828f-d9fde02d2ccc" />

The link further redirects to various affiliate links before redirecting to either DuckDuckGo or Yahoo search engines.

<img width="865" height="121" alt="image" src="https://github.com/user-attachments/assets/75e3d986-b095-4c0c-bfc7-98fa8a10ced4" />
