### PR TITLE
new domain 'mblue.cc' to domains list

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+mblue.cc
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
Adding malicious BlueExpress domain.

## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```

https://mblue.cc/cl

```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```

https://www.blue.cl/

```

## Describe the issue
<!-- Be as clear as possible: nobody can read your mind, and nobody is looking at your issue over your shoulder. -->

Malicious domain targeting BlueExpress customers. BlueExpress is a legit Chilean logistics and last mile company. 

## Related external source
<!-- If you have found your information in another fora, please paste link here. One link per line. -->


### Screenshot
<!-- If you feel a screenshot can say more than 1000 hard drives, do please feel free to add it here

**TIP**: Place your mouse on the line just above the `</details>` 
and paste your screenshot and make sure that there is at least one
line spacing before and after the image code line. The tip will add"
one line after the paste :wink: -->

<details><summary>Click to expand</summary>

<img width="1206" height="2022" alt="IMG_7367" src="https://github.com/user-attachments/assets/2c26db7b-9d06-4052-9b8a-701ffc91fd15" />

</details>
