### PR TITLE
Add ayudaclientes.bntrab.sbs

### DIFF
--- a/additions/temporary/domains.list
+++ b/additions/temporary/domains.list
@@ -1,0 +1,1 @@
+ayudaclientes.bntrab.sbs


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
`ayudaclientes.bntrab.sbs`

## Impersonated domain
`bantrab.com.gt`

## Describe the issue
This domain is being used for active phishing impersonating Bantrab banking services.

The domain is newly created and uses "bntrab" in the hostname, which is visually similar to Bantrab and may deceive users into believing it is an official banking channel.

The site resolves to Namecheap infrastructure and appears to be part of recurring phishing activity targeting Bantrab users.

Host/IP:
`66.29.148.155`

ASN:
`AS22612 NAMECHEAP-NET`

## Related external source
https://urlscan.io/result/019f2343-1381-717f-bf88-ba771a5453d6

## Screenshot

<details><summary>Click to expand</summary>

</details>