### PR TITLE
Block Netflix Phishing Sites

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,5 @@
+www.updatenow.click
+access-authority-2faa9bb814.s3.eu-north-1.amazonaws.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
www.updatenow.click
access-authority-2faa9bb814.s3.eu-north-1.amazonaws.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
netflix.com
```

## Describe the issue
A phishing email was received with a link to `https://access-authority-2faa9bb814.s3.eu-north-1.amazonaws.com/index.html`. The page redirects to various spoofed Netflix page via JavaScript redirection. As of this reporting it is redirecting to `https://www.updatenow.click/index.html`.

<img width="1150" height="622" alt="Screenshot_20260706_213500" src="https://github.com/user-attachments/assets/e2becf2a-7a31-4df4-98a3-e162161ac1ed" />

<img width="896" height="222" alt="Screenshot_20260706_234619" src="https://github.com/user-attachments/assets/f6b55821-5eed-4f57-8017-f2bed5999217" />

<img width="1657" height="1027" alt="Screenshot_20260706_234753" src="https://github.com/user-attachments/assets/0cc5eab9-7b36-48d2-9e80-deb4281be40b" />


## Related external source
https://phishtank.org/phish_detail.php?phish_id=9470838
https://phishtank.org/phish_detail.php?phish_id=9470837

