### PR TITLE
Block Additional BDO Phishing Sites

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,5 @@
+bdo-c1.cc
+bdo-kk.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
Related to https://github.com/Phishing-Database/phishing/pull/1211

## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
bdo-c1.cc
bdo-kk.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
bdo.com.ph
```

## Describe the issue
The exact mechanism is identical with https://github.com/Phishing-Database/phishing/pull/1211

<img width="1280" height="517" alt="image" src="https://github.com/user-attachments/assets/a60b3432-ffe4-4a2e-ba47-d2d68b9da85c" />

<img width="1656" height="1352" alt="Screenshot 2026-07-10 at 18-53-34 Personal BDO Unibank Inc" src="https://github.com/user-attachments/assets/63e5c23c-66d3-42dc-b7ac-1cf09834f3ae" />

<img width="1656" height="1578" alt="Screenshot 2026-07-10 at 18-53-57 Personal BDO Unibank Inc" src="https://github.com/user-attachments/assets/1b9fa2e2-f0f8-40cd-8555-cb40c48d0634" />

<img width="1656" height="994" alt="Screenshot 2026-07-10 at 18-54-30 Personal BDO Unibank Inc" src="https://github.com/user-attachments/assets/af9a416f-17f1-4fca-99cd-67ab1a5c3283" />

<img width="1656" height="1284" alt="Screenshot 2026-07-10 at 18-55-19 Personal BDO Unibank Inc" src="https://github.com/user-attachments/assets/d66d0053-a869-4d49-b73f-2a1339040e15" />

<img width="1656" height="994" alt="Screenshot 2026-07-10 at 18-55-56 Personal BDO Unibank Inc" src="https://github.com/user-attachments/assets/557868bd-6ad6-4139-bd67-469b28efa650" />


## Related external source
https://phishtank.org/phish_detail.php?phish_id=9474024
https://phishtank.org/phish_detail.php?phish_id=9474026
https://github.com/Phishing-Database/phishing/pull/1211