### PR TITLE
Block appsync.live

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+appsync.live
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
appsync.live
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
ledger.com
```

## Describe the issue
A phishing email spoofing Ledger was received with a link to `https://appsync.live/restore/`.

<img width="1620" height="970" alt="Screenshot_20260804_215943" src="https://github.com/user-attachments/assets/e4917d78-2a66-48b7-a4d3-d5f60b3f3319" />

When accessed using a desktop browser it redirects to `https://2m.ma`

<img width="1656" height="1032" alt="Screenshot_20260804_221253" src="https://github.com/user-attachments/assets/5c0bf73f-98f1-47d0-ab0c-8913e1905392" />

But when accessed using a mobile browser it redirects to its own spoofed page of Ledger `https://appsync.live/restore/app/m`.

<img width="509" height="994" alt="image" src="https://github.com/user-attachments/assets/01192db5-3fc1-42f5-9bb7-f2bd96e876f9" />

## Related external source
https://phishtank.org/phish_detail.php?phish_id=9496580
