### PR TITLE
Block open-seaconnect.com

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+open-seaconnect.com
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
open-seaconnect.com
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
opensea.io
```

## Describe the issue
A phishing email was received with a link to a tracker that redirects to `https://open-seaconnect.com/`. The page impersonates OpenSea, a known crypto assets exchange.

<img width="647" height="898" alt="Screenshot_20260809_193902" src="https://github.com/user-attachments/assets/91974db5-33d0-4a9c-9eea-54d2ac0e079f" />

<img width="1657" height="1032" alt="image" src="https://github.com/user-attachments/assets/555260c4-3198-4d5e-a76e-8a4d67ff06b5" />


## Related external source
https://phishtank.org/phish_detail.php?phish_id=9501090
