### PR TITLE
Block nimbusroot.org

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,4 +1,5 @@
 nimbusroot.org
+domavaxen.org
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com

--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+nimbusroot.org
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
nimbusroot.org
domavaxen.org
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
Registrar spoofing
```

## Describe the issue
A phishing email from a fake registrar notice (`administrator@domavaxen.org`) was received. The adversary sends phishing emails using the domain registrant's WHOIS records.

<img width="1330" height="792" alt="Screenshot_20260818_112620" src="https://github.com/user-attachments/assets/4bff657e-559e-42e4-a887-518b65be2c86" />

<img width="1656" height="2543" alt="Screenshot 2026-08" src="https://github.com/user-attachments/assets/c9d8fbad-8e6a-410f-bb31-c43d0637707a" />

## Related external source
https://www.virustotal.com/gui/url/cb58f7f9d127723645e8fff918306b3f8fe8deaf6cd51871664249eb8e2195de?nocache=1
https://phishtank.org/phish_detail.php?phish_id=9506597