### PR TITLE
Block jtexpress.mwkqbr.club and related links

### DIFF
--- a/additions/permanent/domains.list
+++ b/additions/permanent/domains.list
@@ -1,3 +1,4 @@
+jtexpress.mwkqbr.club
 0ffice365-1drvve-oneauthmx1drive.glitch.me
 1-67c.pages.dev
 109.197.125.34.bc.googleusercontent.com

--- a/additions/permanent/domains.wildcard.list
+++ b/additions/permanent/domains.wildcard.list
@@ -1,3 +1,4 @@
+mwkqbr.club
 123pan.cn
 13afx.top
 17fdg.xyz

--- a/additions/permanent/links.list
+++ b/additions/permanent/links.list
@@ -1,3 +1,5 @@
+https://jtexpress.mwkqbr.club/com/#/index
+https://jtexpress.mwkqbr.club/com/
 http://147.45.44.131/infopage/resafh7.exe
 http://147.45.44.131/infopage/vgqvs.bat
 http://147.45.44.131/infopage/vtqrai.exe


### PR DESCRIPTION
## Phishing Domain/URL/IP(s):
<!-- Required. Use Back ticks. -->
```
https://jtexpress.mwkqbr.club/com/#/index
https://jtexpress.mwkqbr.club/com
jtexpress.mwkqbr.club
mwkqbr.club
```


## Impersonated domain
<!-- Required. Use Back ticks. -->
```
www.jtexpress.ph
```

## Describe the issue
First reported in a LinkedIn post (https://lnkd.in/p/efgYPWww):

```
Received a [J&T Express](https://www.linkedin.com/company/jtexpressglobal/) smishing SMS. It asked me to update my Barangay details and helpfully included a "collection OTP" for a parcel. Of course, not expecting any. 🤣 

Spent 30 minutes on the kit. 

Findings:

It is not a static phishing page. It runs [socket.io] with a live operator console. You type your card in, a human runs the real transaction, and the panel then serves you whichever verification screen your bank asks for. Dedicated routes for SMS OTP, email OTP, card PIN, bank app approval and Amex CVV.

The victim is the second factor. 3D Secure defeated by social engineering, not by breaking crypto.

Other details: Domain registered 17 August through a Hong Kong registrar, Cloudflare fronted, detects headless browsers and serves crawlers a blank shell, Chinese page names left untranslated in the bundle, and a UK variant that also harvests National Insurance Number and date of birth.

The branding, corporate address and app QR were scraped straight from the real J&T PH site.

One rule that would have stopped all of it: never reply, not even "Y". Replying is what re-enables the link your phone blocked on purpose.
```

<img width="480" height="1043" alt="1787102092856" src="https://github.com/user-attachments/assets/26cc6635-8433-4d06-b958-a3c8547806a3" />

The link goes to a spoofed page of J&T Express, a well known delivery platform in the Philippines.

<img width="1656" height="5972" alt="Screenshot 2026-08-19 at 10-36-15 " src="https://github.com/user-attachments/assets/f75933aa-174f-46e3-81ea-036d4acbfbcb" />

Clicking on the page button shows a form that collects personal information.

<img width="1656" height="1029" alt="image" src="https://github.com/user-attachments/assets/16268d0e-50c6-4061-84f7-5e0b40c413d3" />

Then another form to get card information appears.

<img width="1656" height="1029" alt="Screenshot_20260819_104947" src="https://github.com/user-attachments/assets/34b50843-b5db-4d65-8bdf-2e25b8000746" />

It then contacts the adversary's server via Web Sockets to pass information.

<img width="1540" height="378" alt="Screenshot_20260819_104718" src="https://github.com/user-attachments/assets/d1d246cf-493a-44a1-9b40-155a494ee3b9" />

It also created a cookie and a couple of entries in the browser's local storage.

<img width="1540" height="255" alt="Screenshot_20260819_104032" src="https://github.com/user-attachments/assets/13254736-819c-4c23-a56d-563441dec23f" />

<img width="1540" height="255" alt="Screenshot_20260819_104503" src="https://github.com/user-attachments/assets/e122b3fe-3820-43f1-906d-f13172dc0c56" />

Entering fake information shows this warning.

<img width="1656" height="1029" alt="Screenshot_20260819_105135" src="https://github.com/user-attachments/assets/0958400a-f8e9-42e1-a691-92345da32db0" />


## Related external source
https://lnkd.in/p/efgYPWww
https://phishtank.org/phish_detail.php?phish_id=9507334
https://www.virustotal.com/gui/url/b9bae30e8c712e8c73987a5eeb21f9fb6076fa522ef3a2ab03799cc40bd8066e/detection